### PR TITLE
Support multiple currencies on coupons

### DIFF
--- a/src/Coupon/FixedDiscountHandler.php
+++ b/src/Coupon/FixedDiscountHandler.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Coupon;
 
+use Laravel\Cashier\Exceptions\CurrencyMismatchException;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Order\OrderItemCollection;
 use Money\Money;
@@ -21,7 +22,12 @@ class FixedDiscountHandler extends BaseCouponHandler
         /** @var OrderItem $firstItem */
         $firstItem = $items->first();
 
+
         $unitPrice = $this->unitPrice($firstItem->getTotal());
+
+        if (! $unitPrice->isSameCurrency($firstItem->getTotal())) {
+            throw new CurrencyMismatchException('All actions must be in the same currency');
+        }
 
         return $this->makeOrderItem([
             'process_at' => now(),

--- a/src/FirstPayment/Actions/ApplySubscriptionCouponToPayment.php
+++ b/src/FirstPayment/Actions/ApplySubscriptionCouponToPayment.php
@@ -30,6 +30,7 @@ class ApplySubscriptionCouponToPayment extends BaseNullAction
     {
         $this->owner = $owner;
         $this->coupon = $coupon;
+        $this->currency = $coupon->context()['discount']['currency'] ?? null;
         $this->orderItems = $this->coupon->handler()->getDiscountOrderItems($orderItems);
     }
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -420,6 +420,41 @@ abstract class BaseTestCase extends TestCase
     }
 
     /**
+     * @param \Laravel\Cashier\Coupon\Coupon $coupon
+     * @param null $couponHandler
+     * @param null $context
+     * @return CouponRepository The mocked coupon repository
+     */
+    protected function withMockedUsdCouponRepository(Coupon $coupon = null, $couponHandler = null, $context = null)
+    {
+        if (is_null($couponHandler)) {
+            $couponHandler = new FixedDiscountHandler;
+        }
+
+        if (is_null($context)) {
+            $context = [
+                'description' => 'Test USD coupon',
+                'discount' => [
+                    'value' => '5.00',
+                    'currency' => 'USD',
+                ],
+            ];
+        }
+
+        if (is_null($coupon)) {
+            $coupon = new Coupon(
+                'usddiscount',
+                $couponHandler,
+                $context
+            );
+        }
+
+        return $this->mock(CouponRepository::class, function ($mock) use ($coupon) {
+            return $mock->shouldReceive('findOrFail')->with($coupon->name())->andReturn($coupon);
+        });
+    }
+
+    /**
      * Register an instance of an object in the container.
      * Included for Laravel 5.5 / 5.6 compatibility.
      *

--- a/tests/Coupon/MultiCurrencyCouponOrderItemPreprocessorTest.php
+++ b/tests/Coupon/MultiCurrencyCouponOrderItemPreprocessorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Coupon;
+
+use Laravel\Cashier\Coupon\AppliedCoupon;
+use Laravel\Cashier\Coupon\Contracts\CouponRepository;
+use Laravel\Cashier\Coupon\CouponOrderItemPreprocessor;
+use Laravel\Cashier\Exceptions\CurrencyMismatchException;
+use Laravel\Cashier\Order\OrderItem;
+use Laravel\Cashier\Order\OrderItemCollection;
+use Laravel\Cashier\Subscription;
+use Laravel\Cashier\Tests\BaseTestCase;
+
+class MultiCurrencyCouponOrderItemPreprocessorTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withPackageMigrations();
+    }
+
+    /** @test */
+    public function appliesCoupon()
+    {
+        $this->withMockedUsdCouponRepository();
+
+        /** @var Subscription $subscription */
+        $subscription = factory(Subscription::class)->create();
+        $item = factory(OrderItem::class)->make();
+        $subscription->orderItems()->save($item);
+
+        /** @var Subscription $subscriptionUsd */
+        $subscriptionUsd = factory(Subscription::class)->create();
+        $itemUsd = factory(OrderItem::class)->make(['currency' => 'USD']);
+        $subscriptionUsd->orderItems()->save($itemUsd);
+
+        /** @var \Laravel\Cashier\Coupon\Coupon $coupon */
+        $usdCoupon = app()->make(CouponRepository::class)->findOrFail('usddiscount');
+
+        $redeemedUsdCoupon = $usdCoupon->redeemFor($subscription);
+        $preprocessor = new CouponOrderItemPreprocessor();
+
+        $this->assertEquals(0, AppliedCoupon::count());
+        $this->assertEquals(1, $redeemedUsdCoupon->times_left);
+
+        $this->expectException(CurrencyMismatchException::class);
+        $preprocessor->handle($item->toCollection());
+
+
+        $redeemedUsdCoupon = $usdCoupon->redeemFor($subscriptionUsd);
+        $preprocessor = new CouponOrderItemPreprocessor();
+
+        $this->assertEquals(0, AppliedCoupon::count());
+        $this->assertEquals(1, $redeemedUsdCoupon->times_left);
+
+
+        $result = $preprocessor->handle($itemUsd->toCollection());
+
+        $this->assertEquals(1, AppliedCoupon::count());
+        $this->assertInstanceOf(OrderItemCollection::class, $result);
+        $this->assertNotEquals($item->toCollection(), $result);
+        $this->assertEquals(0, $redeemedUsdCoupon->refresh()->times_left);
+    }
+}


### PR DESCRIPTION
`null` is applied for currency when the coupon handler  is `PercentageDiscountHandler::class`