### PR TITLE
Change columns order for upgrade cashier

### DIFF
--- a/database/migrations/upgrade_to_cashier_v2.php.stub
+++ b/database/migrations/upgrade_to_cashier_v2.php.stub
@@ -14,8 +14,8 @@ class UpgradeToCashierV2 extends Migration
     public function up()
     {
         Schema::table('orders', function (Blueprint $table) {
-            $table->unsignedInteger('amount_refunded')->default(0);
-            $table->unsignedInteger('amount_charged_back')->default(0);
+            $table->unsignedInteger('amount_refunded')->after('total_due')->default(0);
+            $table->unsignedInteger('amount_charged_back')->after('amount_refunded')->default(0);
         });
 
         Schema::create('refunds', function (Blueprint $table) {


### PR DESCRIPTION
If you're upgrading from cashier v1 to v2, the columns `amount_refunded` and `amount_charged_back` are placed after the timestamps (end) of the table. 

With this pull request they are added after total_due same as the initial migration for v2.