### PR TITLE
Fix webhook if chargeback is executed by customer

### DIFF
--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -34,8 +34,8 @@ class AftercareWebhookController extends BaseWebhookController
         if ($molliePayment && $molliePayment->hasChargebacks()) {
             $localPayment = Payment::findByPaymentId($molliePayment->id);
 
-            if ($localPayment->amount_charged_back < mollie_object_to_money($molliePayment->amountChargedBack)) {
-                $localPayment->amount_charged_back = mollie_object_to_money($molliePayment->amountChargedBack);
+            if ($localPayment->amount_charged_back < mollie_object_to_money($molliePayment->amountChargedBack)->getAmount()) {
+                $localPayment->amount_charged_back = mollie_object_to_money($molliePayment->amountChargedBack)->getAmount();
                 $localPayment->save();
 
                 Event::dispatch(new ChargebackReceived($localPayment, $molliePayment->amountChargedBack - $localPayment->amount_charged_back));


### PR DESCRIPTION
This pull request will fix the following issue: https://github.com/mollie/laravel-cashier-mollie/issues/29

`Object of class Money\Money could not be converted to int on`