### PR TITLE
Allows cancelled subscription to be swapped at next cycle.

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -241,12 +241,12 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
         /** @var Plan $newPlan */
         $newPlan = app(PlanRepository::class)::findOrFail($plan);
 
-        if ($this->cancelled()) {
-            $this->cycle_ends_at = $this->ends_at;
-            $this->ends_at = null;
-        }
-
         return DB::transaction(function () use ($plan, $newPlan) {
+            if ($this->cancelled()) {
+                $this->cycle_ends_at = $this->ends_at;
+                $this->ends_at = null;
+            }
+
             $this->next_plan = $plan;
 
             $this->removeScheduledOrderItem();
@@ -291,7 +291,6 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
             $this->fill([
                 'ends_at' => $endsAt,
                 'cycle_ends_at' => null,
-//                'next_plan' => null,
             ])->save();
 
             Event::dispatch(new SubscriptionCancelled($this, $reason));

--- a/tests/SwapSubscriptionPlanTest.php
+++ b/tests/SwapSubscriptionPlanTest.php
@@ -137,6 +137,24 @@ class SwapSubscriptionPlanTest extends BaseTestCase
     }
 
     /** @test */
+    public function swappingACancelledSubscriptionAtNextCycleResumesIt()
+    {
+        $subscription = $this->getUser()->subscriptions()->save(
+            factory(Cashier::$subscriptionModel)->make([
+                'ends_at' => now()->addWeek(),
+                'plan' => 'monthly-20-1',
+            ])
+        );
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->cancelled());
+
+        $subscription->swapNextCycle('weekly-20-1');
+
+        $this->assertFalse($subscription->cancelled());
+    }
+
+    /** @test */
     public function canSwapNextCycle()
     {
         $user = $this->getUserWithZeroBalance();


### PR DESCRIPTION
When swapping a cancelled subscription to a different plan immediately using `$subscription->swap('new_plan)` this is supported, however when using `$subscription->swapNextCycle('new_plan')` it results in a TypeError:

> TypeError: Laravel\Cashier\Subscription::scheduleNewOrderItemAt(): Argument #1 ($process_at) must be of type Carbon\Carbon, null given, called in /Projects/sources/laravel-cashier-mollie/src/Subscription.php on line 248

This pull request adds support for swapping cancelled subscriptions at the next cycle.