### PR TITLE
Clears next_plan upon cancelling of subscription.

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -285,6 +285,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
             $this->fill([
                 'ends_at' => $endsAt,
                 'cycle_ends_at' => null,
+                'next_plan' => null,
             ])->save();
 
             Event::dispatch(new SubscriptionCancelled($this, $reason));

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -492,6 +492,28 @@ class SubscriptionTest extends BaseTestCase
     }
 
     /** @test */
+    public function cancellingASubscriptionWithNextPlanClearsNextPlan()
+    {
+        $user = factory(User::class)->create();
+        $subscription = $user->subscriptions()->save(
+            factory(Cashier::$subscriptionModel)->make([
+                'cycle_ends_at' => now()->addWeek(),
+                'next_plan' => 'monthly-10-2', ])
+        );
+
+        $this->assertFalse($subscription->cancelled());
+        $this->assertTrue($subscription->active());
+
+        $subscription->cancelNow();
+
+        $this->assertCarbon(now(), $subscription->ends_at);
+        $this->assertNull($subscription->cycle_ends_at);
+        $this->assertNull($subscription->next_plan);
+        $this->assertTrue($subscription->cancelled());
+        $this->assertFalse($subscription->active());
+    }
+
+    /** @test */
     public function resumingACancelledSubscriptionResetsCycleEndsAt()
     {
         $this->withConfiguredPlans();


### PR DESCRIPTION
When cancelling a subscription that was about to swap to another plan (having a `next_plan` defined), the `next_plan` doesn't make sense anymore and probably should be cleared.