### PR TITLE
Remove money helper from code to stop collision

### DIFF
--- a/src/Credit/Credit.php
+++ b/src/Credit/Credit.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\Credit;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Laravel\Cashier\Traits\HasOwner;
+use Money\Currency;
 use Money\Money;
 
 class Credit extends Model
@@ -55,13 +56,13 @@ class Credit extends Model
             $credit = static::whereOwner($owner)->whereCurrency($amount->getCurrency()->getCode())->firstOrCreate([]);
 
             if ($credit->value == 0) {
-                return money(0, $amount->getCurrency()->getCode());
+                return new Money(0, new Currency($amount->getCurrency()->getCode()));
             }
 
             $use_credit = min([$credit->value, (int) $amount->getAmount()]);
             $credit->decrement('value', $use_credit);
 
-            return money($use_credit, $amount->getCurrency()->getCode());
+            return new Money($use_credit, new Currency($amount->getCurrency()->getCode()));
         });
     }
 
@@ -72,6 +73,6 @@ class Credit extends Model
      */
     public function money()
     {
-        return money($this->value, $this->currency);
+        return new Money($this->value, new Currency($this->currency));
     }
 }

--- a/src/FirstPayment/Actions/ActionCollection.php
+++ b/src/FirstPayment/Actions/ActionCollection.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\CurrencyMismatchException;
 use Laravel\Cashier\Order\OrderItemCollection;
+use Money\Currency;
+use Money\Money;
 
 class ActionCollection extends Collection
 {
@@ -32,7 +34,7 @@ class ActionCollection extends Collection
      */
     public function total()
     {
-        $total = money(0, $this->getCurrency());
+        $total = new Money(0, new Currency($this->getCurrency()));
 
         $this->each(function (BaseAction $item) use (&$total) {
             $total = $total->add($item->getTotal());

--- a/src/FirstPayment/Actions/ApplySubscriptionCouponToPayment.php
+++ b/src/FirstPayment/Actions/ApplySubscriptionCouponToPayment.php
@@ -5,6 +5,8 @@ namespace Laravel\Cashier\FirstPayment\Actions;
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Cashier\Coupon\Coupon;
 use Laravel\Cashier\Order\OrderItemCollection;
+use Money\Currency;
+use Money\Money;
 
 class ApplySubscriptionCouponToPayment extends BaseNullAction
 {
@@ -57,6 +59,6 @@ class ApplySubscriptionCouponToPayment extends BaseNullAction
      */
     protected function toMoney($value = 0)
     {
-        return money($value, $this->getCurrency());
+        return new Money($value, new Currency($this->getCurrency()));
     }
 }

--- a/src/FirstPayment/Actions/StartSubscription.php
+++ b/src/FirstPayment/Actions/StartSubscription.php
@@ -10,6 +10,8 @@ use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Plan\Contracts\PlanRepository;
 use Laravel\Cashier\SubscriptionBuilder\Contracts\SubscriptionConfigurator;
 use Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder;
+use Money\Currency;
+use Money\Money;
 
 class StartSubscription extends BaseAction implements SubscriptionConfigurator
 {
@@ -215,7 +217,7 @@ class StartSubscription extends BaseAction implements SubscriptionConfigurator
     {
         $this->trialDays = $trialDays;
         $this->builder()->trialDays($trialDays);
-        $this->unitPrice = money(0, $this->getCurrency());
+        $this->unitPrice = new Money(0, new Currency($this->getCurrency()));
 
         return $this;
     }
@@ -230,7 +232,7 @@ class StartSubscription extends BaseAction implements SubscriptionConfigurator
     {
         $this->trialUntil = $trialUntil;
         $this->builder()->trialUntil($trialUntil);
-        $this->unitPrice = money(0, $this->getCurrency());
+        $this->unitPrice = new Money(0, new Currency($this->getCurrency()));
 
         return $this;
     }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -23,20 +23,6 @@ if (! function_exists('object_to_array_recursive')) {
     }
 }
 
-if (! function_exists('money')) {
-    /**
-     * Create a Money object from a Mollie Amount array.
-     *
-     * @param  int  $value
-     * @param  string  $currency
-     * @return \Money\Money
-     */
-    function money(int $value, string $currency)
-    {
-        return new Money($value, new Currency($currency));
-    }
-}
-
 if (! function_exists('decimal_to_money')) {
     /**
      * Create a Money object from a decimal string / currency pair.

--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -12,6 +12,8 @@ use Laravel\Cashier\Refunds\Refund;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Resources\Refund as MollieRefund;
 use Mollie\Api\Types\RefundStatus;
+use Money\Currency;
+use Money\Money;
 use Symfony\Component\HttpFoundation\Response;
 
 class AftercareWebhookController extends BaseWebhookController
@@ -80,7 +82,7 @@ class AftercareWebhookController extends BaseWebhookController
             // Update the locally known refunded amount
             $amountRefunded = $molliePayment->amountRefunded
                 ? mollie_object_to_money($molliePayment->amountRefunded)
-                : money(0, $molliePayment->amount->currency);
+                : new Money(0, new Currency($molliePayment->amount->currency));
 
             $localPayment = Cashier::$paymentModel::findByPaymentId($molliePayment->id);
             $localPayment->update(['amount_refunded' => (int) $amountRefunded->getAmount()]);

--- a/src/Order/ConvertsToMoney.php
+++ b/src/Order/ConvertsToMoney.php
@@ -2,6 +2,9 @@
 
 namespace Laravel\Cashier\Order;
 
+use Money\Currency;
+use Money\Money;
+
 trait ConvertsToMoney
 {
     /**
@@ -10,6 +13,6 @@ trait ConvertsToMoney
      */
     protected function toMoney($value = 0)
     {
-        return money(round($value), $this->getCurrency());
+        return new Money(round($value), new Currency($this->getCurrency()));
     }
 }

--- a/src/Order/Invoice.php
+++ b/src/Order/Invoice.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Order\Contracts\InvoicableItem;
 use Laravel\Cashier\Traits\FormatsAmount;
+use Money\Currency;
 use Money\Money;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -201,7 +202,7 @@ class Invoice
      */
     public function rawSubtotal()
     {
-        $subtotal = money(0, $this->currency);
+        $subtotal = new Money(0, new Currency($this->currency));
 
         $this->items->each(function (InvoicableItem $item) use (&$subtotal) {
             $subtotal = $subtotal->add($item->getSubtotal());
@@ -227,7 +228,7 @@ class Invoice
      */
     public function rawTotal()
     {
-        $subtotal = money(0, $this->currency);
+        $subtotal = new Money(0, new Currency($this->currency));
 
         $this->items->each(function (InvoicableItem $item) use (&$subtotal) {
             $subtotal = $subtotal->add($item->getTotal());
@@ -279,9 +280,9 @@ class Invoice
             return [
                 'tax_percentage' => (float) $percentage,
                 'raw_over_subtotal' => $raw_over_subtotal,
-                'over_subtotal' => $this->formatAmount(money($raw_over_subtotal, $this->currency)),
+                'over_subtotal' => $this->formatAmount(new Money($raw_over_subtotal, new Currency($this->currency))),
                 'raw_total' => $raw_total,
-                'total' => $this->formatAmount(money($raw_total, $this->currency)),
+                'total' => $this->formatAmount(new Money($raw_total, new Currency($this->currency))),
             ];
         };
 
@@ -330,7 +331,7 @@ class Invoice
      */
     public function rawStartingBalance()
     {
-        return $this->startingBalance ?: money(0, $this->currency);
+        return $this->startingBalance ?: new Money(0, new Currency($this->currency));
     }
 
     /**
@@ -361,7 +362,7 @@ class Invoice
      */
     public function rawUsedBalance()
     {
-        return $this->usedBalance ?: money(0, $this->currency);
+        return $this->usedBalance ?: new Money(0, new Currency($this->currency));
     }
 
     /**
@@ -392,7 +393,7 @@ class Invoice
      */
     public function rawCompletedBalance()
     {
-        return $this->completedBalance ?: money(0, $this->currency);
+        return $this->completedBalance ?: new Money(0, new Currency($this->currency));
     }
 
     /**

--- a/src/Order/OrderItemCollection.php
+++ b/src/Order/OrderItemCollection.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 use Laravel\Cashier\Cashier;
 use LogicException;
+use Money\Currency;
 use Money\Money;
 
 class OrderItemCollection extends Collection
@@ -169,7 +170,7 @@ class OrderItemCollection extends Collection
             throw new LogicException('Calculating the total requires items to be of the same currency.');
         }
 
-        return money($this->sum('total'), $this->currency());
+        return new Money($this->sum('total'), new Currency($this->currency()));
     }
 
     public function currency(): string

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -9,6 +9,7 @@ use Laravel\Cashier\Order\ConvertsToMoney;
 use Laravel\Cashier\Traits\HasOwner;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Types\PaymentStatus;
+use Money\Currency;
 use Money\Money;
 
 /**
@@ -72,11 +73,11 @@ class Payment extends Model
     {
         $amountChargedBack = $payment->amountChargedBack
             ? mollie_object_to_money($payment->amountChargedBack)
-            : money(0, $payment->amount->currency);
+            : new Money(0, new Currency($payment->amount->currency));
 
         $amountRefunded = $payment->amountRefunded
             ? mollie_object_to_money($payment->amountRefunded)
-            : money(0, $payment->amount->currency);
+            : new Money(0, new Currency($payment->amount->currency));
 
         $localActions = ! empty($actions) ? $actions : $payment->metadata->actions ?? null;
 

--- a/src/Refunds/RefundItemCollection.php
+++ b/src/Refunds/RefundItemCollection.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Order\OrderItemCollection;
+use Money\Currency;
 use Money\Money;
 
 class RefundItemCollection extends Collection
@@ -23,7 +24,8 @@ class RefundItemCollection extends Collection
 
     public function getTotal(): Money
     {
-        return money($this->sum('total'), $this->getCurrency());
+        return new Money($this->sum('total'), new Currency($this->getCurrency()));
+
     }
 
     public function getCurrency(): string

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -24,6 +24,7 @@ use Laravel\Cashier\Refunds\RefundItem;
 use Laravel\Cashier\Traits\HasOwner;
 use Laravel\Cashier\Types\SubscriptionCancellationReason;
 use LogicException;
+use Money\Currency;
 use Money\Money;
 
 /**
@@ -692,7 +693,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
      */
     protected function reimbursableAmount()
     {
-        $zeroAmount = \money('0.00', $this->currency);
+        $zeroAmount = new Money('0.00', new Currency($this->currency));
 
         // Determine base amount eligible to reimburse
         $latestProcessedOrderItem = $this->latestProcessedOrderItem();

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -14,6 +14,7 @@ use Laravel\Cashier\Tests\Fixtures\User;
 use Mockery;
 use Mollie\Api\MollieApiClient;
 use Mollie\Laravel\Wrappers\MollieApiWrapper;
+use Money\Currency;
 use Money\Money;
 use Orchestra\Testbench\TestCase;
 
@@ -374,7 +375,7 @@ abstract class BaseTestCase extends TestCase
     {
         $this->assertEquals($currency, $money->getCurrency()->getCode());
         $this->assertEquals($money->getAmount(), $value);
-        $this->assertTrue(money($value, $currency)->equals($money));
+        $this->assertTrue((new Money($value, new Currency($currency)))->equals($money));
     }
 
     /**

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -32,6 +32,8 @@ use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\Payment;
+use Money\Currency;
+use Money\Money;
 
 class CashierTest extends BaseTestCase
 {
@@ -302,8 +304,8 @@ class CashierTest extends BaseTestCase
     /** @test */
     public function testFormatAmount()
     {
-        $this->assertEquals('1.000,00 €', Cashier::formatAmount(money(100000, 'EUR')));
-        $this->assertEquals('-9.123,45 €', Cashier::formatAmount(money(-912345, 'EUR')));
+        $this->assertEquals('1.000,00 €', Cashier::formatAmount(new Money(100000, new Currency('EUR'))));
+        $this->assertEquals('-9.123,45 €', Cashier::formatAmount(new Money(-912345, new Currency('EUR'))));
     }
 
     /**
@@ -415,14 +417,14 @@ class CashierTest extends BaseTestCase
     protected function withMockedGetMollieMethodMinimumAmount($times = 1): void
     {
         $this->mock(GetMollieMethodMinimumAmount::class, function ($mock) use ($times) {
-            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(100, 'EUR'));
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(new Money(100, new Currency('EUR')));
         });
     }
 
     protected function withMockedGetMollieMethodMaximumAmount($times = 1): void
     {
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) use ($times) {
-            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(30000, 'EUR'));
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(new Money(30000, new Currency('EUR')));
         });
     }
 

--- a/tests/Charge/FirstPaymentChargeBuilderTest.php
+++ b/tests/Charge/FirstPaymentChargeBuilderTest.php
@@ -10,6 +10,8 @@ use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Payment as MolliePayment;
+use Money\Currency;
+use Money\Money;
 
 class FirstPaymentChargeBuilderTest extends BaseTestCase
 {
@@ -35,12 +37,12 @@ class FirstPaymentChargeBuilderTest extends BaseTestCase
         $this->assertEquals(0, $owner->orders()->count());
 
         $item = new \Laravel\Cashier\Charge\ChargeItemBuilder($owner);
-        $item->unitPrice(money(100, 'EUR'));
+        $item->unitPrice(new Money(100, new Currency('EUR')));
         $item->description('Test Item');
         $chargeItem = $item->make();
 
         $item2 = new \Laravel\Cashier\Charge\ChargeItemBuilder($owner);
-        $item2->unitPrice(money(200, 'EUR'));
+        $item2->unitPrice(new Money(200, new Currency('EUR')));
         $item2->description('Test Item 2');
         $chargeItem2 = $item2->make();
 

--- a/tests/FirstPayment/Actions/AddBalanceTest.php
+++ b/tests/FirstPayment/Actions/AddBalanceTest.php
@@ -7,6 +7,8 @@ use Laravel\Cashier\FirstPayment\Actions\AddBalance;
 use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Money\Currency;
+use Money\Money;
 
 class AddBalanceTest extends BaseTestCase
 {
@@ -16,7 +18,7 @@ class AddBalanceTest extends BaseTestCase
         $this->withPackageMigrations();
         $action = new AddBalance(
             $this->getMandatedUser(),
-            money(1000, 'EUR'),
+            new Money(1000, new Currency('EUR')),
             1,
             'Adding some test balance'
         );
@@ -64,7 +66,7 @@ class AddBalanceTest extends BaseTestCase
 
         $action = new AddBalance(
             $user,
-            money(1000, 'EUR'),
+            new Money(1000, new Currency('EUR')),
             1,
             'Adding some test balance'
         );

--- a/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
+++ b/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
@@ -7,6 +7,8 @@ use Laravel\Cashier\FirstPayment\Actions\AddGenericOrderItem;
 use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Money\Currency;
+use Money\Money;
 
 class AddGenericOrderItemTest extends BaseTestCase
 {
@@ -17,7 +19,7 @@ class AddGenericOrderItemTest extends BaseTestCase
 
         $action = new AddGenericOrderItem(
             $this->getMandatedUser(true, ['tax_percentage' => 20]),
-            money(5, 'EUR'),
+            new Money(5, new Currency('EUR')),
             1,
             'Adding a test order item'
         );
@@ -82,7 +84,7 @@ class AddGenericOrderItemTest extends BaseTestCase
 
         $action = new AddGenericOrderItem(
             $user,
-            money(5, 'EUR'),
+            new Money(5, new Currency('EUR')),
             1,
             'Adding a test order item'
         );

--- a/tests/FirstPayment/FirstPaymentBuilderTest.php
+++ b/tests/FirstPayment/FirstPaymentBuilderTest.php
@@ -15,6 +15,8 @@ use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Types\SequenceType;
+use Money\Currency;
+use Money\Money;
 
 class FirstPaymentBuilderTest extends BaseTestCase
 {
@@ -46,13 +48,13 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $builder->inOrderTo([
             new AddBalance(
                 $owner,
-                money(500, 'EUR'),
+                new Money(500, new Currency('EUR')),
                 1,
                 'Test add balance 1'
             ),
             new AddBalance(
                 $owner,
-                money(500, 'EUR'),
+                new Money(500, new Currency('EUR')),
                 1,
                 'Test add balance 2'
             ),
@@ -99,13 +101,13 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $builder->inOrderTo([
             new AddBalance(
                 $owner,
-                money(500, 'EUR'),
+                new Money(500, new Currency('EUR')),
                 1,
                 'Test add balance 1'
             ),
             new AddBalance(
                 $owner,
-                money(500, 'EUR'),
+                new Money(500, new Currency('EUR')),
                 1,
                 'Test add balance 2'
             ),
@@ -187,7 +189,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
         });
 
         $payment = $builder->inOrderTo([
-            new AddGenericOrderItem($owner, money(100, 'EUR'), 1, 'Parse redirectUrl test'),
+            new AddGenericOrderItem($owner, new Money(100, new Currency('EUR')), 1, 'Parse redirectUrl test'),
         ])->create();
 
         $this->assertEquals('https://www.example.com/tr_unique_id', $payment->redirectUrl);
@@ -208,13 +210,13 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $builder->inOrderTo([
             new AddBalance(
                 $owner,
-                money(500, 'EUR'),
+                new Money(500, new Currency('EUR')),
                 1,
                 'Test add balance 1'
             ),
             new AddBalance(
                 $owner,
-                money(500, 'EUR'),
+                new Money(500, new Currency('EUR')),
                 1,
                 'Test add balance 2'
             ),

--- a/tests/Helpers/HelpersTest.php
+++ b/tests/Helpers/HelpersTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Helpers;
 
+use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 
@@ -10,7 +11,7 @@ class HelpersTest extends TestCase
     /** @test */
     public function testMoney()
     {
-        $money = money(1234, 'EUR');
+        $money = new Money(1234, new Currency('EUR'));
 
         $this->assertInstanceOf(Money::class, $money);
         $this->assertTrue(Money::EUR(1234)->equals($money));

--- a/tests/ManageSubscriptionTest.php
+++ b/tests/ManageSubscriptionTest.php
@@ -18,6 +18,8 @@ use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\Payment;
+use Money\Currency;
+use Money\Money;
 
 class ManageSubscriptionTest extends BaseTestCase
 {
@@ -341,14 +343,14 @@ class ManageSubscriptionTest extends BaseTestCase
     protected function withMockedGetMollieMethodMinimumAmount($times = 1): void
     {
         $this->mock(GetMollieMethodMinimumAmount::class, function ($mock) use ($times) {
-            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(100, 'EUR'));
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(new Money(100, new Currency('EUR')));
         });
     }
 
     protected function withMockedGetMollieMethodMaximumAmount($times = 1): void
     {
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) use ($times) {
-            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(30000, 'EUR'));
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(new Money(30000, new Currency('EUR')));
         });
     }
 

--- a/tests/Order/InvoiceTest.php
+++ b/tests/Order/InvoiceTest.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Order\Invoice;
 use Laravel\Cashier\Tests\BaseTestCase;
+use Money\Currency;
+use Money\Money;
 
 class InvoiceTest extends BaseTestCase
 {
@@ -130,7 +132,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertMoneyEURCents(0, $invoice->rawStartingBalance());
         $this->assertEquals('0,00 €', $invoice->startingBalance());
 
-        $invoice = $invoice->setStartingBalance(money(1525, 'EUR'));
+        $invoice = $invoice->setStartingBalance(new Money(1525, new Currency('EUR')));
         $this->assertTrue($invoice->hasStartingBalance());
         $this->assertMoneyEURCents(1525, $invoice->rawStartingBalance());
         $this->assertEquals('15,25 €', $invoice->startingBalance());
@@ -143,7 +145,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertMoneyEURCents(0, $invoice->rawCompletedBalance());
         $this->assertEquals('0,00 €', $invoice->completedBalance());
 
-        $invoice = $invoice->setCompletedBalance(money(1525, 'EUR'));
+        $invoice = $invoice->setCompletedBalance(new Money(1525, new Currency('EUR')));
         $this->assertMoneyEURCents(1525, $invoice->rawCompletedBalance());
         $this->assertEquals('15,25 €', $invoice->completedBalance());
     }
@@ -155,7 +157,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertMoneyEURCents(0, $invoice->rawUsedBalance());
         $this->assertEquals('0,00 €', $invoice->usedBalance());
 
-        $invoice = $invoice->setUsedBalance(money(1525, 'EUR'));
+        $invoice = $invoice->setUsedBalance(new Money(1525, new Currency('EUR')));
         $this->assertMoneyEURCents(1525, $invoice->rawUsedBalance());
         $this->assertEquals('15,25 €', $invoice->usedBalance());
     }

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -27,6 +27,8 @@ use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\PaymentStatus;
+use Money\Currency;
+use Money\Money;
 
 class OrderTest extends BaseTestCase
 {
@@ -69,14 +71,14 @@ class OrderTest extends BaseTestCase
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(10, 'EUR'));
+                ->andReturn(new Money(10, new Currency('EUR')));
         });
 
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) {
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(30000, 'EUR'));
+                ->andReturn(new Money(30000, new Currency('EUR')));
         });
 
         $this->mock(CreateMolliePayment::class, function ($mock) {
@@ -191,7 +193,7 @@ class OrderTest extends BaseTestCase
         // Owner with 15 euro balance
         $user = $this
             ->getMandatedUser(true, ['id' => 2])
-            ->addCredit(money(1500, 'EUR'));
+            ->addCredit(new Money(1500, new Currency('EUR')));
 
         $this->assertMoneyEURCents(1500, $user->credit('EUR')->money());
 
@@ -338,14 +340,14 @@ class OrderTest extends BaseTestCase
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(10, 'EUR'));
+                ->andReturn(new Money(10, new Currency('EUR')));
         });
 
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) {
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(30000, 'EUR'));
+                ->andReturn(new Money(30000, new Currency('EUR')));
         });
 
         $this->mock(CreateMolliePayment::class, function ($mock) {
@@ -416,7 +418,7 @@ class OrderTest extends BaseTestCase
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(10, 'EUR'));
+                ->andReturn(new Money(10, new Currency('EUR')));
         });
 
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) {
@@ -494,14 +496,14 @@ class OrderTest extends BaseTestCase
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(1, 'EUR'));
+                ->andReturn(new Money(1, new Currency('EUR')));
         });
 
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) {
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(10, 'EUR'));
+                ->andReturn(new Money(10, new Currency('EUR')));
         });
 
         $user = $this->getMandatedUser(true, [
@@ -603,14 +605,14 @@ class OrderTest extends BaseTestCase
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(10, 'EUR'));
+                ->andReturn(new Money(10, new Currency('EUR')));
         });
 
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) {
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(30000, 'EUR'));
+                ->andReturn(new Money(30000, new Currency('EUR')));
         });
 
         $this->mock(CreateMolliePayment::class, function ($mock) {
@@ -691,14 +693,14 @@ class OrderTest extends BaseTestCase
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(100, 'EUR'));
+                ->andReturn(new Money(100, new Currency('EUR')));
         });
 
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) {
             return $mock->shouldReceive('execute')
                 ->with('directdebit', 'EUR')
                 ->once()
-                ->andReturn(money(30000, 'EUR'));
+                ->andReturn(new Money(30000, new Currency('EUR')));
         });
 
         $user = $this->getMandatedUser(true, [
@@ -747,7 +749,7 @@ class OrderTest extends BaseTestCase
             'currency' => 'EUR',
         ]));
         $this->assertFalse($order->isProcessed());
-        $user->addCredit(money(1025, 'EUR'));
+        $user->addCredit(new Money(1025, new Currency('EUR')));
         $this->assertTrue($user->hasCredit('EUR'));
         $this->assertEquals(1025, $user->credit('EUR')->value);
         $this->assertMoneyEURCents(1025, $user->credit('EUR')->money());
@@ -856,7 +858,7 @@ class OrderTest extends BaseTestCase
         Carbon::setTestNow(Carbon::parse('2018-01-01'));
         Event::fake();
         $user = factory(User::class)->create(); // user without subscription/mandate
-        $user->addCredit(money(29998, 'EUR'));
+        $user->addCredit(new Money(29998, new Currency('EUR')));
 
         factory(Cashier::$orderItemModel, 2)->create([
             'orderable_type' => null,
@@ -980,7 +982,7 @@ class OrderTest extends BaseTestCase
     public function generateNewExampleInvoice()
     {
         $user = factory(User::class)->create(['extra_billing_information' => 'Some dummy extra billing information']);
-        $user->addCredit(money(500, 'EUR'));
+        $user->addCredit(new Money(500, new Currency('EUR')));
         $items = factory(Cashier::$orderItemModel, 2)->states(['unlinked', 'EUR'])->create([
             'owner_id' => $user->id,
             'owner_type' => User::class,

--- a/tests/SwapSubscriptionPlanTest.php
+++ b/tests/SwapSubscriptionPlanTest.php
@@ -17,6 +17,8 @@ use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Customer;
 use Mollie\Api\Resources\Mandate;
 use Mollie\Api\Resources\Payment;
+use Money\Currency;
+use Money\Money;
 
 class SwapSubscriptionPlanTest extends BaseTestCase
 {
@@ -254,14 +256,14 @@ class SwapSubscriptionPlanTest extends BaseTestCase
     protected function withMockedGetMollieMethodMinimumAmount($times = 1): void
     {
         $this->mock(GetMollieMethodMinimumAmount::class, function ($mock) use ($times) {
-            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(100, 'EUR'));
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(new Money(100, new Currency('EUR')));
         });
     }
 
     protected function withMockedGetMollieMethodMaximumAmount($times = 1): void
     {
         $this->mock(GetMollieMethodMaximumAmount::class, function ($mock) use ($times) {
-            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(money(30000, 'EUR'));
+            return $mock->shouldReceive('execute')->with('directdebit', 'EUR')->times($times)->andReturn(new Money(30000, new Currency('EUR')));
         });
     }
 


### PR DESCRIPTION
In one of my projects I installed a package that depended on the akaunting/money package. These both use a money helper. The akaunting/money package overrides the money helper in the laravel-cashier-mollie package in my case. 

This pull requests removes the money helper from the client code and directly uses the Money and Currency class. The tests still use the helper, but for users of the package that shouldn't matter. 