### PR TITLE
Revert removing money helper

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -23,6 +23,20 @@ if (! function_exists('object_to_array_recursive')) {
     }
 }
 
+if (! function_exists('money')) {
+    /**
+     * Create a Money object from a Mollie Amount array.
+     *
+     * @param  int|string  $value
+     * @param  string  $currency
+     * @return \Money\Money
+     */
+    function money($value, string $currency)
+    {
+        return new Money($value, new Currency($currency));
+    }
+}
+
 if (! function_exists('decimal_to_money')) {
     /**
      * Create a Money object from a decimal string / currency pair.

--- a/tests/Helpers/HelpersTest.php
+++ b/tests/Helpers/HelpersTest.php
@@ -11,7 +11,7 @@ class HelpersTest extends TestCase
     /** @test */
     public function testMoney()
     {
-        $money = new Money(1234, new Currency('EUR'));
+        $money = money(1234, 'EUR');
 
         $this->assertInstanceOf(Money::class, $money);
         $this->assertTrue(Money::EUR(1234)->equals($money));


### PR DESCRIPTION
Reverts removing the `money(...)` helper function, which was part of: https://github.com/mollie/laravel-cashier-mollie/pull/119