### PR TITLE
Pass through  object to getInvoiceInformation method

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -63,10 +63,11 @@ Once you have pulled in the package:
         /**
         * Get the receiver information for the invoice.
         * Typically includes the name and some sort of (E-mail/physical) address.
+        * The $order argument contains information about the order
         *
         * @return array An array of strings
         */
-        public function getInvoiceInformation()
+        public function getInvoiceInformation( $order )
         {
             return [$this->name, $this->email];
         }

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -323,7 +323,7 @@ class Order extends Model
             ->setCompletedBalance($this->getBalanceAfter())
             ->setUsedBalance($this->getCreditUsed());
 
-        $invoice->setReceiverAddress($this->owner->getInvoiceInformation());
+        $invoice->setReceiverAddress($this->owner->getInvoiceInformation( $this ));
 
         $extra_information = null;
         $owner = $this->owner;


### PR DESCRIPTION
By passing through the $Order to the getInvoiceInformation, information from the order can be used in the `getInvoiceInformation` function.

I haven't add the $order to the `Laravel\Cashier\Order\Contracts\ProvidesInvoiceInformation` interface, so it's an optional attribute, and it doesn't break existing installations. 