### PR TITLE
Makes getting order description a function

### DIFF
--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -239,7 +239,7 @@ class Order extends Model
 
                     $payment = (new MandatedPaymentBuilder(
                         $owner,
-                        trans('cashier::payment.description', ['number' => $this->number], Cashier::getLocale($owner)),
+                        $this->getDescription(),
                         $totalDue,
                         url(config('cashier.webhook_url')),
                         [
@@ -622,6 +622,16 @@ class Order extends Model
     public function getCurrency()
     {
         return $this->currency;
+    }
+
+    /**
+     * Get the description used when creating a mollie order.
+     * 
+     * @return string
+     */
+    public function getDescription()
+    {
+        return trans('cashier::payment.description', ['number' => $this->number], Cashier::getLocale($this->owner));
     }
 
     /**


### PR DESCRIPTION
Hey,

This updates getting the order description to use a function. This allows the users of the package to easily implement a dynamic description instead of having to overwrite the full 'processPayment' function. 

For my use case, I would like to have the order description contain a small description for each order item that it includes.