### PR TITLE
Fix using $this in static context in Subscription.php

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -638,13 +638,13 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
         $subscription = $item->orderable;
 
         if ($subscription->ends_at !== null) {
-            DB::transaction(function () use ($item) {
-                if (! $this->scheduled_order_item_id) {
-                    $item = $this->scheduleNewOrderItemAt($this->ends_at);
+            DB::transaction(function () use ($item, $subscription) {
+                if (! $subscription->scheduled_order_item_id) {
+                    $item = $subscription->scheduleNewOrderItemAt($subscription->ends_at);
                 }
 
-                $this->fill([
-                    'cycle_ends_at' => $this->plan()->interval()->getEndOfNextSubscriptionCycle($this),
+                $subscription->fill([
+                    'cycle_ends_at' => $subscription->plan()->interval()->getEndOfNextSubscriptionCycle($subscription),
                     'ends_at' => null,
                     'scheduled_order_item_id' => $item->id,
                 ])->save();


### PR DESCRIPTION

The updated Subscription::handlePaymentPaid changed in #220 is a static function, but tries to use `$this`. This causes php to throw an exception `Error: Using $this when not in object context`. The `$subscription` variable is already available, so this could be used instead of `$this`.
