### PR TITLE
OAuth support

### DIFF
--- a/docs/17-oauth.md
+++ b/docs/17-oauth.md
@@ -1,0 +1,46 @@
+# OAuth
+
+You have the possibility to use OAuth (optional).
+
+This could be useful when you want to give customers the option to process payments within your application.
+
+## Setting up the model
+
+Your billable model needs to implement the `Laravel\Cashier\Contracts\ProvidesOauthInformation` interface.
+
+```php
+namespace App\Models;
+
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
+
+class User extends Model implements ProvidesOauthInformation;
+{
+    ... your code
+
+    /**
+     * Get the OAuth token.
+     */
+    public function getOauthToken(): string
+    {
+        return $user->mollie_access_token;
+    }
+
+    /**
+     * Get the Mollie Profile ID.
+     */
+    public function getMollieProfile(): string
+    {
+        return $user->mollie_profile_id;
+    }
+
+    /**
+     * Get whether the Mollie API is in test mode.
+     */
+    public function isMollieTestmode(): bool
+    {
+        return ! app()->environment('production');
+    }
+}
+```
+
+After implementing the interface on your billable models, let the magic happen :sparkles:

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -6,7 +6,7 @@ use Dompdf\Options;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Laravel\Cashier\Charge\ManagesCharges;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
 use Laravel\Cashier\Events\MandateClearedFromBillable;
 use Laravel\Cashier\Exceptions\InvalidMandateException;
@@ -169,7 +169,7 @@ trait Billable
         $createMollieCustomer = app()->make(CreateMollieCustomer::class);
         $customer = $createMollieCustomer->execute(
             $options,
-            $this instanceof ProvidesOauthToken ? $this : null,
+            $this instanceof ProvidesOauthInformation ? $this : null,
         );
 
         $this->{$this->getMollieCustomerIdColumn()} = $customer->id;
@@ -194,7 +194,7 @@ trait Billable
 
         return $getMollieCustomer->execute(
             $this->{$this->getMollieCustomerIdColumn()},
-            $this instanceof ProvidesOauthToken ? $this : null,
+            $this instanceof ProvidesOauthInformation ? $this : null,
         );
     }
 
@@ -465,7 +465,7 @@ trait Billable
                 return $getMollieMandate->execute(
                     $customer->id,
                     $mandateId,
-                    $this instanceof ProvidesOauthToken ? $this : null,
+                    $this instanceof ProvidesOauthInformation ? $this : null,
                 );
             } catch (ApiException $e) {
                 // Status 410: mandate was revoked

--- a/src/Contracts/ProvidesOauthInformation.php
+++ b/src/Contracts/ProvidesOauthInformation.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier\Contracts;
 
-interface ProvidesOauthToken
+interface ProvidesOauthInformation
 {
     /**
      * Get the OAuth token.
@@ -13,4 +13,9 @@ interface ProvidesOauthToken
      * Get the Mollie Profile ID.
      */
     public function getMollieProfile(): string;
+
+    /**
+     * Get whether the Mollie API is in test mode.
+     */
+    public function isMollieTestmode(): bool;
 }

--- a/src/Contracts/ProvidesOauthToken.php
+++ b/src/Contracts/ProvidesOauthToken.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Cashier\Contracts;
+
+interface ProvidesOauthToken
+{
+    /**
+     * Get the OAuth token.
+     */
+    public function getOauthToken(): string;
+
+    /**
+     * Get the Mollie Profile ID.
+     */
+    public function getMollieProfile(): string;
+}

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -5,7 +5,7 @@ namespace Laravel\Cashier\FirstPayment;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\FirstPayment\Actions\ActionCollection;
 use Laravel\Cashier\FirstPayment\Traits\PaymentMethodString;
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
@@ -137,7 +137,7 @@ class FirstPaymentBuilder
         $createMolliePayment = app()->make(CreateMolliePayment::class);
         $this->molliePayment = $createMolliePayment->execute(
             $payload,
-            $this->owner instanceof ProvidesOauthToken ? $this->owner : null,
+            $this->owner instanceof ProvidesOauthInformation ? $this->owner : null,
         );
 
         Cashier::$paymentModel::createFromMolliePayment(
@@ -158,7 +158,7 @@ class FirstPaymentBuilder
             $updateMolliePayment = app()->make(UpdateMolliePayment::class);
             $this->molliePayment = $updateMolliePayment->execute(
                 $this->molliePayment,
-                $this->owner instanceof ProvidesOauthToken ? $this->owner : null,
+                $this->owner instanceof ProvidesOauthInformation ? $this->owner : null,
             );
         }
 

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\FirstPayment;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\FirstPayment\Actions\ActionCollection;
 use Laravel\Cashier\FirstPayment\Traits\PaymentMethodString;
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
@@ -134,7 +135,10 @@ class FirstPaymentBuilder
 
         /** @var CreateMolliePayment $createMolliePayment */
         $createMolliePayment = app()->make(CreateMolliePayment::class);
-        $this->molliePayment = $createMolliePayment->execute($payload);
+        $this->molliePayment = $createMolliePayment->execute(
+            $payload,
+            $this->owner instanceof ProvidesOauthToken ? $this->owner : null,
+        );
 
         Cashier::$paymentModel::createFromMolliePayment(
             $this->molliePayment,
@@ -152,7 +156,10 @@ class FirstPaymentBuilder
 
             /** @var UpdateMolliePayment $updateMolliePayment */
             $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-            $this->molliePayment = $updateMolliePayment->execute($this->molliePayment);
+            $this->molliePayment = $updateMolliePayment->execute(
+                $this->molliePayment,
+                $this->owner instanceof ProvidesOauthToken ? $this->owner : null,
+            );
         }
 
         return $this->molliePayment;

--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Events\ChargebackReceived;
 use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Refunds\Refund;
@@ -31,7 +31,7 @@ class AftercareWebhookController extends BaseWebhookController
 
         $molliePayment = $this->getMolliePaymentById(
             $request->get('id'),
-            owner: $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null,
+            owner: $payment->owner instanceof ProvidesOauthInformation ? $payment->owner : null,
         );
 
         if ($molliePayment && $molliePayment->hasRefunds()) {

--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -9,7 +9,6 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Events\ChargebackReceived;
 use Laravel\Cashier\Order\Order;
-use Laravel\Cashier\Payment;
 use Laravel\Cashier\Refunds\Refund;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Resources\Refund as MollieRefund;
@@ -28,7 +27,7 @@ class AftercareWebhookController extends BaseWebhookController
      */
     public function handleWebhook(Request $request)
     {
-        $payment = Payment::with('owner')->firstWhere('mollie_payment_id', $request->get('id'));
+        $payment = Cashier::$paymentModel::with('owner')->firstWhere('mollie_payment_id', $request->get('id'));
 
         $molliePayment = $this->getMolliePaymentById(
             $request->get('id'),

--- a/src/Http/Controllers/BaseWebhookController.php
+++ b/src/Http/Controllers/BaseWebhookController.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Http\Controllers;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Mollie\Api\Exceptions\ApiException;
 
@@ -23,14 +24,15 @@ abstract class BaseWebhookController
      *
      * @param  string  $id
      * @param  array  $parameters
+     * @param  \Laravel\Cashier\Contracts\ProvidesOauthToken|null  $owner
      * @return \Mollie\Api\Resources\Payment|null
      *
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function getMolliePaymentById(string $id, array $parameters = [])
+    public function getMolliePaymentById(string $id, array $parameters = [], ?ProvidesOauthToken $owner = null)
     {
         try {
-            return $this->getMolliePayment->execute($id, $parameters);
+            return $this->getMolliePayment->execute($id, $parameters, $owner);
         } catch (ApiException $e) {
             if (! config('app.debug')) {
                 // Prevent leaking information

--- a/src/Http/Controllers/FirstPaymentWebhookController.php
+++ b/src/Http/Controllers/FirstPaymentWebhookController.php
@@ -5,7 +5,7 @@ namespace Laravel\Cashier\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Events\FirstPaymentFailed;
 use Laravel\Cashier\Events\FirstPaymentPaid;
 use Laravel\Cashier\FirstPayment\FirstPaymentHandler;
@@ -26,7 +26,7 @@ class FirstPaymentWebhookController extends BaseWebhookController
 
         $molliePayment = $this->getMolliePaymentById(
             $request->get('id'),
-            owner: $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null,
+            owner: $payment->owner instanceof ProvidesOauthInformation ? $payment->owner : null,
         );
 
         if ($molliePayment) {
@@ -38,7 +38,7 @@ class FirstPaymentWebhookController extends BaseWebhookController
                 $updateMolliePayment = app()->make(UpdateMolliePayment::class);
                 $molliePayment = $updateMolliePayment->execute(
                     $molliePayment,
-                    $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null
+                    $payment->owner instanceof ProvidesOauthInformation ? $payment->owner : null
                 );
 
                 Event::dispatch(new FirstPaymentPaid($molliePayment, $order));

--- a/src/Http/Controllers/FirstPaymentWebhookController.php
+++ b/src/Http/Controllers/FirstPaymentWebhookController.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Events\FirstPaymentFailed;
 use Laravel\Cashier\Events\FirstPaymentPaid;
 use Laravel\Cashier\FirstPayment\FirstPaymentHandler;
@@ -20,6 +21,7 @@ class FirstPaymentWebhookController extends BaseWebhookController
      */
     public function handleWebhook(Request $request)
     {
+        // TODO @younes, add retrieving with oauth token.
         $payment = $this->getMolliePaymentById($request->get('id'));
 
         if ($payment) {
@@ -29,7 +31,7 @@ class FirstPaymentWebhookController extends BaseWebhookController
 
                 /** @var UpdateMolliePayment $updateMolliePayment */
                 $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-                $payment = $updateMolliePayment->execute($payment);
+                $payment = $updateMolliePayment->execute($payment, $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null);
 
                 Event::dispatch(new FirstPaymentPaid($payment, $order));
             } elseif ($payment->isFailed()) {

--- a/src/Http/Controllers/FirstPaymentWebhookController.php
+++ b/src/Http/Controllers/FirstPaymentWebhookController.php
@@ -4,12 +4,12 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Events\FirstPaymentFailed;
 use Laravel\Cashier\Events\FirstPaymentPaid;
 use Laravel\Cashier\FirstPayment\FirstPaymentHandler;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
-use Laravel\Cashier\Payment;
 use Symfony\Component\HttpFoundation\Response;
 
 class FirstPaymentWebhookController extends BaseWebhookController
@@ -22,7 +22,7 @@ class FirstPaymentWebhookController extends BaseWebhookController
      */
     public function handleWebhook(Request $request)
     {
-        $payment = Payment::with('owner')->firstWhere('mollie_payment_id', $request->get('id'));
+        $payment = Cashier::$paymentModel::with('owner')->firstWhere('mollie_payment_id', $request->get('id'));
 
         $molliePayment = $this->getMolliePaymentById(
             $request->get('id'),

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
-use Laravel\Cashier\Payment as CashierPayment;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\PaymentStatus;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +20,7 @@ class WebhookController extends BaseWebhookController
      */
     public function handleWebhook(Request $request)
     {
-        $payment = CashierPayment::with('owner')->firstWhere('mollie_payment_id', $request->get('id'));
+        $payment = Cashier::$paymentModel::with('owner')->firstWhere('mollie_payment_id', $request->get('id'));
 
         $molliePayment = $this->getMolliePaymentById(
             $request->get('id'),

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\PaymentStatus;
@@ -19,6 +20,7 @@ class WebhookController extends BaseWebhookController
      */
     public function handleWebhook(Request $request)
     {
+        // TODO @younes, add retrieving with oauth token.
         $payment = $this->getMolliePaymentById($request->get('id'));
 
         if ($payment) {
@@ -32,7 +34,7 @@ class WebhookController extends BaseWebhookController
 
                         /** @var UpdateMolliePayment $updateMolliePayment */
                         $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-                        $updateMolliePayment->execute($payment);
+                        $updateMolliePayment->execute($payment, $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null);
 
                         break;
                     case PaymentStatus::STATUS_FAILED:

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -4,7 +4,7 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
 use Mollie\Api\Resources\Payment;
 use Mollie\Api\Types\PaymentStatus;
@@ -24,7 +24,7 @@ class WebhookController extends BaseWebhookController
 
         $molliePayment = $this->getMolliePaymentById(
             $request->get('id'),
-            owner: $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null,
+            owner: $payment->owner instanceof ProvidesOauthInformation ? $payment->owner : null,
         );
 
         if ($molliePayment) {
@@ -38,7 +38,7 @@ class WebhookController extends BaseWebhookController
 
                         /** @var UpdateMolliePayment $updateMolliePayment */
                         $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-                        $updateMolliePayment->execute($molliePayment, $payment->owner instanceof ProvidesOauthToken ? $payment->owner : null);
+                        $updateMolliePayment->execute($molliePayment, $payment->owner instanceof ProvidesOauthInformation ? $payment->owner : null);
 
                         break;
                     case PaymentStatus::STATUS_FAILED:

--- a/src/MandatedPayment/MandatedPaymentBuilder.php
+++ b/src/MandatedPayment/MandatedPaymentBuilder.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\MandatedPayment;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
 use Mollie\Api\Types\SequenceType;
 use Money\Money;
@@ -85,7 +86,7 @@ class MandatedPaymentBuilder
     {
         /** @var CreateMolliePayment $createMolliePayment */
         $createMolliePayment = app()->make(CreateMolliePayment::class);
-        $molliePayment = $createMolliePayment->execute($this->getPayload($overrides));
+        $molliePayment = $createMolliePayment->execute($this->getPayload($overrides), $this->owner instanceof ProvidesOauthToken ? $this->owner : null);
 
         Cashier::$paymentModel::createFromMolliePayment($molliePayment, $this->owner);
 

--- a/src/MandatedPayment/MandatedPaymentBuilder.php
+++ b/src/MandatedPayment/MandatedPaymentBuilder.php
@@ -4,7 +4,7 @@ namespace Laravel\Cashier\MandatedPayment;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
 use Mollie\Api\Types\SequenceType;
 use Money\Money;
@@ -86,7 +86,7 @@ class MandatedPaymentBuilder
     {
         /** @var CreateMolliePayment $createMolliePayment */
         $createMolliePayment = app()->make(CreateMolliePayment::class);
-        $molliePayment = $createMolliePayment->execute($this->getPayload($overrides), $this->owner instanceof ProvidesOauthToken ? $this->owner : null);
+        $molliePayment = $createMolliePayment->execute($this->getPayload($overrides), $this->owner instanceof ProvidesOauthInformation ? $this->owner : null);
 
         Cashier::$paymentModel::createFromMolliePayment($molliePayment, $this->owner);
 

--- a/src/MaximumPayment.php
+++ b/src/MaximumPayment.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMaximumAmount;
 use Laravel\Cashier\Order\Contracts\MaximumPayment as MaximumPaymentContract;
 use Mollie\Api\Resources\Mandate;
@@ -14,7 +14,7 @@ class MaximumPayment implements MaximumPaymentContract
      * @param $currency
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null)
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthInformation $model = null)
     {
         /** @var GetMollieMethodMaximumAmount $getMaximumAmount */
         $getMaximumAmount = app()->make(GetMollieMethodMaximumAmount::class);

--- a/src/MaximumPayment.php
+++ b/src/MaximumPayment.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMaximumAmount;
 use Laravel\Cashier\Order\Contracts\MaximumPayment as MaximumPaymentContract;
 use Mollie\Api\Resources\Mandate;
@@ -13,11 +14,11 @@ class MaximumPayment implements MaximumPaymentContract
      * @param $currency
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency)
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null)
     {
         /** @var GetMollieMethodMaximumAmount $getMaximumAmount */
         $getMaximumAmount = app()->make(GetMollieMethodMaximumAmount::class);
 
-        return $getMaximumAmount->execute($mandate->method, $currency);
+        return $getMaximumAmount->execute($mandate->method, $currency, $model);
     }
 }

--- a/src/MinimumPayment.php
+++ b/src/MinimumPayment.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMinimumAmount;
 use Laravel\Cashier\Order\Contracts\MinimumPayment as MinimumPaymentContract;
 use Mollie\Api\Resources\Mandate;
@@ -14,7 +14,7 @@ class MinimumPayment implements MinimumPaymentContract
      * @param $currency
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null)
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthInformation $model = null)
     {
         /** @var GetMollieMethodMinimumAmount $getMinimumAmount */
         $getMinimumAmount = app()->make(GetMollieMethodMinimumAmount::class);

--- a/src/MinimumPayment.php
+++ b/src/MinimumPayment.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMollieMethodMinimumAmount;
 use Laravel\Cashier\Order\Contracts\MinimumPayment as MinimumPaymentContract;
 use Mollie\Api\Resources\Mandate;
@@ -13,11 +14,11 @@ class MinimumPayment implements MinimumPaymentContract
      * @param $currency
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency)
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null)
     {
         /** @var GetMollieMethodMinimumAmount $getMinimumAmount */
         $getMinimumAmount = app()->make(GetMollieMethodMinimumAmount::class);
 
-        return $getMinimumAmount->execute($mandate->method, $currency);
+        return $getMinimumAmount->execute($mandate->method, $currency, $model);
     }
 }

--- a/src/Mollie/BaseMollieInteraction.php
+++ b/src/Mollie/BaseMollieInteraction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\MollieApiClient as Mollie;
 
 abstract class BaseMollieInteraction
@@ -16,5 +17,15 @@ abstract class BaseMollieInteraction
     public function __construct(Mollie $mollie)
     {
         $this->mollie = $mollie;
+    }
+
+    /**
+     * Set the OAuth token to be used by the interaction.
+     */
+    public function setAccessToken(?ProvidesOauthToken $model = null): void
+    {
+        if ($model && ($token = $model->getOauthToken())) {
+            $this->mollie->setAccessToken($token);
+        }
     }
 }

--- a/src/Mollie/BaseMollieInteraction.php
+++ b/src/Mollie/BaseMollieInteraction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\MollieApiClient as Mollie;
 
 abstract class BaseMollieInteraction
@@ -22,9 +22,9 @@ abstract class BaseMollieInteraction
     /**
      * Set the OAuth token to be used by the interaction.
      */
-    public function setAccessToken(?ProvidesOauthToken $model = null): void
+    public function setAccessToken(?ProvidesOauthInformation $model = null): void
     {
-        if ($model && ($token = $model->getOauthToken())) {
+        if ($token = $model?->getOauthToken()) {
             $this->mollie->setAccessToken($token);
         }
     }

--- a/src/Mollie/Contracts/CreateMollieCustomer.php
+++ b/src/Mollie/Contracts/CreateMollieCustomer.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Customer;
 
 interface CreateMollieCustomer
 {
-    public function execute(array $payload): Customer;
+    public function execute(array $payload, ?ProvidesOauthToken $model = null): Customer;
 }

--- a/src/Mollie/Contracts/CreateMollieCustomer.php
+++ b/src/Mollie/Contracts/CreateMollieCustomer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Customer;
 
 interface CreateMollieCustomer
 {
-    public function execute(array $payload, ?ProvidesOauthToken $model = null): Customer;
+    public function execute(array $payload, ?ProvidesOauthInformation $model = null): Customer;
 }

--- a/src/Mollie/Contracts/CreateMolliePayment.php
+++ b/src/Mollie/Contracts/CreateMolliePayment.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Payment;
 
 interface CreateMolliePayment
 {
-    public function execute(array $payload, ?ProvidesOauthToken $model = null): Payment;
+    public function execute(array $payload, ?ProvidesOauthInformation $model = null): Payment;
 }

--- a/src/Mollie/Contracts/CreateMolliePayment.php
+++ b/src/Mollie/Contracts/CreateMolliePayment.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Payment;
 
 interface CreateMolliePayment
 {
-    public function execute(array $payload): Payment;
+    public function execute(array $payload, ?ProvidesOauthToken $model = null): Payment;
 }

--- a/src/Mollie/Contracts/CreateMollieRefund.php
+++ b/src/Mollie/Contracts/CreateMollieRefund.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Refund;
 
 interface CreateMollieRefund
 {
-    public function execute(string $paymentId, array $payload): Refund;
+    public function execute(string $paymentId, array $payload, ?ProvidesOauthToken $model = null): Refund;
 }

--- a/src/Mollie/Contracts/CreateMollieRefund.php
+++ b/src/Mollie/Contracts/CreateMollieRefund.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Refund;
 
 interface CreateMollieRefund
 {
-    public function execute(string $paymentId, array $payload, ?ProvidesOauthToken $model = null): Refund;
+    public function execute(string $paymentId, array $payload, ?ProvidesOauthInformation $model = null): Refund;
 }

--- a/src/Mollie/Contracts/GetMollieCustomer.php
+++ b/src/Mollie/Contracts/GetMollieCustomer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Customer;
 
 interface GetMollieCustomer
 {
-    public function execute(string $id, ?ProvidesOauthToken $model = null): Customer;
+    public function execute(string $id, ?ProvidesOauthInformation $model = null): Customer;
 }

--- a/src/Mollie/Contracts/GetMollieCustomer.php
+++ b/src/Mollie/Contracts/GetMollieCustomer.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Customer;
 
 interface GetMollieCustomer
 {
-    public function execute(string $id): Customer;
+    public function execute(string $id, ?ProvidesOauthToken $model = null): Customer;
 }

--- a/src/Mollie/Contracts/GetMollieMandate.php
+++ b/src/Mollie/Contracts/GetMollieMandate.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Mandate;
 
 interface GetMollieMandate
 {
-    public function execute(string $customerId, string $mandateId): Mandate;
+    public function execute(string $customerId, string $mandateId, ?ProvidesOauthToken $model = null): Mandate;
 }

--- a/src/Mollie/Contracts/GetMollieMandate.php
+++ b/src/Mollie/Contracts/GetMollieMandate.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Mandate;
 
 interface GetMollieMandate
 {
-    public function execute(string $customerId, string $mandateId, ?ProvidesOauthToken $model = null): Mandate;
+    public function execute(string $customerId, string $mandateId, ?ProvidesOauthInformation $model = null): Mandate;
 }

--- a/src/Mollie/Contracts/GetMollieMethodMaximumAmount.php
+++ b/src/Mollie/Contracts/GetMollieMethodMaximumAmount.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Money\Money;
 
 interface GetMollieMethodMaximumAmount
 {
-    public function execute(string $method, string $currency): ?Money;
+    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): ?Money;
 }

--- a/src/Mollie/Contracts/GetMollieMethodMaximumAmount.php
+++ b/src/Mollie/Contracts/GetMollieMethodMaximumAmount.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Money\Money;
 
 interface GetMollieMethodMaximumAmount
 {
-    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): ?Money;
+    public function execute(string $method, string $currency, ?ProvidesOauthInformation $model = null): ?Money;
 }

--- a/src/Mollie/Contracts/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/Contracts/GetMollieMethodMinimumAmount.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Money\Money;
 
 interface GetMollieMethodMinimumAmount
 {
-    public function execute(string $method, string $currency): Money;
+    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): Money;
 }

--- a/src/Mollie/Contracts/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/Contracts/GetMollieMethodMinimumAmount.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Money\Money;
 
 interface GetMollieMethodMinimumAmount
 {
-    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): Money;
+    public function execute(string $method, string $currency, ?ProvidesOauthInformation $model = null): Money;
 }

--- a/src/Mollie/Contracts/GetMolliePayment.php
+++ b/src/Mollie/Contracts/GetMolliePayment.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Payment;
 
 interface GetMolliePayment
 {
-    public function execute(string $id, array $parameters = [], ?ProvidesOauthToken $model = null): Payment;
+    public function execute(string $id, array $parameters = [], ?ProvidesOauthInformation $model = null): Payment;
 }

--- a/src/Mollie/Contracts/GetMolliePayment.php
+++ b/src/Mollie/Contracts/GetMolliePayment.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Payment;
 
 interface GetMolliePayment
 {
-    public function execute(string $id, array $parameters = []): Payment;
+    public function execute(string $id, array $parameters = [], ?ProvidesOauthToken $model = null): Payment;
 }

--- a/src/Mollie/Contracts/GetMollieRefund.php
+++ b/src/Mollie/Contracts/GetMollieRefund.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Refund;
 
 interface GetMollieRefund
 {
-    public function execute(string $paymentId, string $refundId): Refund;
+    public function execute(string $paymentId, string $refundId, ?ProvidesOauthToken $model = null): Refund;
 }

--- a/src/Mollie/Contracts/GetMollieRefund.php
+++ b/src/Mollie/Contracts/GetMollieRefund.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Refund;
 
 interface GetMollieRefund
 {
-    public function execute(string $paymentId, string $refundId, ?ProvidesOauthToken $model = null): Refund;
+    public function execute(string $paymentId, string $refundId, ?ProvidesOauthInformation $model = null): Refund;
 }

--- a/src/Mollie/Contracts/UpdateMolliePayment.php
+++ b/src/Mollie/Contracts/UpdateMolliePayment.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Payment;
 
 interface UpdateMolliePayment
 {
-    public function execute(Payment $dirtyPayment, ?ProvidesOauthToken $model = null): Payment;
+    public function execute(Payment $dirtyPayment, ?ProvidesOauthInformation $model = null): Payment;
 }

--- a/src/Mollie/Contracts/UpdateMolliePayment.php
+++ b/src/Mollie/Contracts/UpdateMolliePayment.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Payment;
 
 interface UpdateMolliePayment
 {
-    public function execute(Payment $dirtyPayment): Payment;
+    public function execute(Payment $dirtyPayment, ?ProvidesOauthToken $model = null): Payment;
 }

--- a/src/Mollie/CreateMollieCustomer.php
+++ b/src/Mollie/CreateMollieCustomer.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer as Contract;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Customer;
 
 class CreateMollieCustomer extends BaseMollieInteraction implements Contract
 {
-    public function execute(array $payload): Customer
+    public function execute(array $payload, ?ProvidesOauthToken $model = null): Customer
     {
+        $this->setAccessToken($model);
+
         return $this->mollie->customers->create($payload);
     }
 }

--- a/src/Mollie/CreateMollieCustomer.php
+++ b/src/Mollie/CreateMollieCustomer.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer as Contract;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Customer;
 
 class CreateMollieCustomer extends BaseMollieInteraction implements Contract
 {
-    public function execute(array $payload, ?ProvidesOauthToken $model = null): Customer
+    public function execute(array $payload, ?ProvidesOauthInformation $model = null): Customer
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->customers->create($payload + [
-            'testmode' => ! app()->environment('production'),
-        ]);
+        if ($model?->isMollieTestmode()) {
+            $payload['testmode'] = true;
+        }
+
+        return $this->mollie->customers->create($payload);
     }
 }

--- a/src/Mollie/CreateMollieCustomer.php
+++ b/src/Mollie/CreateMollieCustomer.php
@@ -14,6 +14,8 @@ class CreateMollieCustomer extends BaseMollieInteraction implements Contract
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->customers->create($payload);
+        return $this->mollie->customers->create($payload + [
+            'testmode' => ! app()->environment('production'),
+        ]);
     }
 }

--- a/src/Mollie/CreateMolliePayment.php
+++ b/src/Mollie/CreateMolliePayment.php
@@ -18,6 +18,8 @@ class CreateMolliePayment extends BaseMollieInteraction implements Contract
             $payload['profileId'] = $profile;
         }
 
-        return $this->mollie->payments->create($payload);
+        return $this->mollie->payments->create($payload + [
+            'testmode' => ! app()->environment('production'),
+        ]);
     }
 }

--- a/src/Mollie/CreateMolliePayment.php
+++ b/src/Mollie/CreateMolliePayment.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment as Contract;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Payment;
 
 class CreateMolliePayment extends BaseMollieInteraction implements Contract
 {
-    public function execute(array $payload): Payment
+    public function execute(array $payload, ?ProvidesOauthToken $model = null): Payment
     {
+        $this->setAccessToken($model);
+
+        if ($profile = $model->getMollieProfile()) {
+            $payload['profileId'] = $profile;
+        }
+
         return $this->mollie->payments->create($payload);
     }
 }

--- a/src/Mollie/CreateMolliePayment.php
+++ b/src/Mollie/CreateMolliePayment.php
@@ -5,21 +5,23 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment as Contract;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Payment;
 
 class CreateMolliePayment extends BaseMollieInteraction implements Contract
 {
-    public function execute(array $payload, ?ProvidesOauthToken $model = null): Payment
+    public function execute(array $payload, ?ProvidesOauthInformation $model = null): Payment
     {
         $this->setAccessToken($model);
 
-        if ($profile = $model->getMollieProfile()) {
+        if ($profile = $model?->getMollieProfile()) {
             $payload['profileId'] = $profile;
         }
 
-        return $this->mollie->payments->create($payload + [
-            'testmode' => ! app()->environment('production'),
-        ]);
+        if ($model?->isMollieTestmode()) {
+            $payload['testmode'] = true;
+        }
+
+        return $this->mollie->payments->create($payload);
     }
 }

--- a/src/Mollie/CreateMollieRefund.php
+++ b/src/Mollie/CreateMollieRefund.php
@@ -31,7 +31,9 @@ class CreateMollieRefund extends BaseMollieInteraction implements Contract
         $payment = $this->getMolliePayment->execute($paymentId, [], $model);
 
         /** @var Refund $refund */
-        $refund = $payment->refund($payload);
+        $refund = $payment->refund($payload + [
+            'testmode' => ! app()->environment('production'),
+        ]);
 
         return $refund;
     }

--- a/src/Mollie/CreateMollieRefund.php
+++ b/src/Mollie/CreateMollieRefund.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\CreateMollieRefund as Contract;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Mollie\Api\Resources\Refund;
@@ -23,9 +24,11 @@ class CreateMollieRefund extends BaseMollieInteraction implements Contract
         $this->getMolliePayment = $getMolliePayment;
     }
 
-    public function execute(string $paymentId, array $payload): Refund
+    public function execute(string $paymentId, array $payload, ?ProvidesOauthToken $model = null): Refund
     {
-        $payment = $this->getMolliePayment->execute($paymentId);
+        $this->setAccessToken($model);
+
+        $payment = $this->getMolliePayment->execute($paymentId, [], $model);
 
         /** @var Refund $refund */
         $refund = $payment->refund($payload);

--- a/src/Mollie/GetMollieCustomer.php
+++ b/src/Mollie/GetMollieCustomer.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer as Contract;
 use Mollie\Api\Resources\Customer;
 
 class GetMollieCustomer extends BaseMollieInteraction implements Contract
 {
-    public function execute(string $id): Customer
+    public function execute(string $id, ?ProvidesOauthToken $model = null): Customer
     {
+        $this->setAccessToken($model);
+
         return $this->mollie->customers->get($id);
     }
 }

--- a/src/Mollie/GetMollieCustomer.php
+++ b/src/Mollie/GetMollieCustomer.php
@@ -14,6 +14,8 @@ class GetMollieCustomer extends BaseMollieInteraction implements Contract
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->customers->get($id);
+        return $this->mollie->customers->get($id, [
+            'testmode' => ! app()->environment('production'),
+        ]);
     }
 }

--- a/src/Mollie/GetMollieCustomer.php
+++ b/src/Mollie/GetMollieCustomer.php
@@ -4,18 +4,22 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer as Contract;
 use Mollie\Api\Resources\Customer;
 
 class GetMollieCustomer extends BaseMollieInteraction implements Contract
 {
-    public function execute(string $id, ?ProvidesOauthToken $model = null): Customer
+    public function execute(string $id, ?ProvidesOauthInformation $model = null): Customer
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->customers->get($id, [
-            'testmode' => ! app()->environment('production'),
-        ]);
+        $payload = [];
+
+        if ($model?->isMollieTestmode()) {
+            $payload['testmode'] = true;
+        }
+
+        return $this->mollie->customers->get($id, $payload);
     }
 }

--- a/src/Mollie/GetMollieMandate.php
+++ b/src/Mollie/GetMollieMandate.php
@@ -14,6 +14,8 @@ class GetMollieMandate extends BaseMollieInteraction implements Contract
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->mandates->getForId($customerId, $mandateId);
+        return $this->mollie->mandates->getForId($customerId, $mandateId, [
+            'testmode' => ! app()->environment('production'),
+        ]);
     }
 }

--- a/src/Mollie/GetMollieMandate.php
+++ b/src/Mollie/GetMollieMandate.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMollieMandate as Contract;
 use Mollie\Api\Resources\Mandate;
 
 class GetMollieMandate extends BaseMollieInteraction implements Contract
 {
-    public function execute(string $customerId, string $mandateId): Mandate
+    public function execute(string $customerId, string $mandateId, ?ProvidesOauthToken $model = null): Mandate
     {
+        $this->setAccessToken($model);
+
         return $this->mollie->mandates->getForId($customerId, $mandateId);
     }
 }

--- a/src/Mollie/GetMollieMandate.php
+++ b/src/Mollie/GetMollieMandate.php
@@ -4,18 +4,22 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMollieMandate as Contract;
 use Mollie\Api\Resources\Mandate;
 
 class GetMollieMandate extends BaseMollieInteraction implements Contract
 {
-    public function execute(string $customerId, string $mandateId, ?ProvidesOauthToken $model = null): Mandate
+    public function execute(string $customerId, string $mandateId, ?ProvidesOauthInformation $model = null): Mandate
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->mandates->getForId($customerId, $mandateId, [
-            'testmode' => ! app()->environment('production'),
-        ]);
+        $payload = [];
+
+        if ($model?->isMollieTestmode()) {
+            $payload['testmode'] = true;
+        }
+
+        return $this->mollie->mandates->getForId($customerId, $mandateId, $payload);
     }
 }

--- a/src/Mollie/GetMollieMethodMaximumAmount.php
+++ b/src/Mollie/GetMollieMethodMaximumAmount.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Money\Money;
 
 class GetMollieMethodMaximumAmount extends BaseMollieInteraction implements Contracts\GetMollieMethodMaximumAmount
 {
-    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): ?Money
+    public function execute(string $method, string $currency, ?ProvidesOauthInformation $model = null): ?Money
     {
         $this->setAccessToken($model);
 
         $payload = [
             'currency' => $currency,
-            'testmode' => ! app()->environment('production'),
         ];
 
-        if ($profile = $model->getMollieProfile()) {
+        if ($profile = $model?->getMollieProfile()) {
             $payload['profileId'] = $profile;
+        }
+
+        if ($model?->isMollieTestmode()) {
+            $payload['testmode'] = true;
         }
 
         $maximumAmount = $this->mollie

--- a/src/Mollie/GetMollieMethodMaximumAmount.php
+++ b/src/Mollie/GetMollieMethodMaximumAmount.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Money\Money;
 
 class GetMollieMethodMaximumAmount extends BaseMollieInteraction implements Contracts\GetMollieMethodMaximumAmount
 {
-    public function execute(string $method, string $currency): ?Money
+    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): ?Money
     {
+        $this->setAccessToken($model);
+
+        if ($profile = $model->getMollieProfile()) {
+            $payload['profileId'] = $profile;
+        }
+
         $maximumAmount = $this->mollie
             ->methods
             ->get($method, ['currency' => $currency])

--- a/src/Mollie/GetMollieMethodMaximumAmount.php
+++ b/src/Mollie/GetMollieMethodMaximumAmount.php
@@ -13,13 +13,18 @@ class GetMollieMethodMaximumAmount extends BaseMollieInteraction implements Cont
     {
         $this->setAccessToken($model);
 
+        $payload = [
+            'currency' => $currency,
+            'testmode' => ! app()->environment('production'),
+        ];
+
         if ($profile = $model->getMollieProfile()) {
             $payload['profileId'] = $profile;
         }
 
         $maximumAmount = $this->mollie
             ->methods
-            ->get($method, ['currency' => $currency, 'testmode' => ! app()->environment('production')])
+            ->get($method, $payload)
             ->maximumAmount;
 
         return $maximumAmount ? mollie_object_to_money($maximumAmount) : null;

--- a/src/Mollie/GetMollieMethodMaximumAmount.php
+++ b/src/Mollie/GetMollieMethodMaximumAmount.php
@@ -19,7 +19,7 @@ class GetMollieMethodMaximumAmount extends BaseMollieInteraction implements Cont
 
         $maximumAmount = $this->mollie
             ->methods
-            ->get($method, ['currency' => $currency])
+            ->get($method, ['currency' => $currency, 'testmode' => ! app()->environment('production')])
             ->maximumAmount;
 
         return $maximumAmount ? mollie_object_to_money($maximumAmount) : null;

--- a/src/Mollie/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/GetMollieMethodMinimumAmount.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Money\Money;
 
 class GetMollieMethodMinimumAmount extends BaseMollieInteraction implements Contracts\GetMollieMethodMinimumAmount
 {
-    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): Money
+    public function execute(string $method, string $currency, ?ProvidesOauthInformation $model = null): Money
     {
         $this->setAccessToken($model);
 
         $payload = [
             'currency' => $currency,
-            'testmode' => ! app()->environment('production'),
         ];
 
-        if ($profile = $model->getMollieProfile()) {
+        if ($profile = $model?->getMollieProfile()) {
             $payload['profileId'] = $profile;
+        }
+
+        if ($model?->isMollieTestmode()) {
+            $payload['testmode'] = true;
         }
         
         $minimumAmount = $this->mollie

--- a/src/Mollie/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/GetMollieMethodMinimumAmount.php
@@ -19,7 +19,7 @@ class GetMollieMethodMinimumAmount extends BaseMollieInteraction implements Cont
         
         $minimumAmount = $this->mollie
             ->methods
-            ->get($method, ['currency' => $currency])
+            ->get($method, ['currency' => $currency, 'testmode' => ! app()->environment('production')])
             ->minimumAmount;
 
         return mollie_object_to_money($minimumAmount);

--- a/src/Mollie/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/GetMollieMethodMinimumAmount.php
@@ -13,13 +13,18 @@ class GetMollieMethodMinimumAmount extends BaseMollieInteraction implements Cont
     {
         $this->setAccessToken($model);
 
+        $payload = [
+            'currency' => $currency,
+            'testmode' => ! app()->environment('production'),
+        ];
+
         if ($profile = $model->getMollieProfile()) {
             $payload['profileId'] = $profile;
         }
         
         $minimumAmount = $this->mollie
             ->methods
-            ->get($method, ['currency' => $currency, 'testmode' => ! app()->environment('production')])
+            ->get($method, $payload)
             ->minimumAmount;
 
         return mollie_object_to_money($minimumAmount);

--- a/src/Mollie/GetMollieMethodMinimumAmount.php
+++ b/src/Mollie/GetMollieMethodMinimumAmount.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Money\Money;
 
 class GetMollieMethodMinimumAmount extends BaseMollieInteraction implements Contracts\GetMollieMethodMinimumAmount
 {
-    public function execute(string $method, string $currency): Money
+    public function execute(string $method, string $currency, ?ProvidesOauthToken $model = null): Money
     {
+        $this->setAccessToken($model);
+
+        if ($profile = $model->getMollieProfile()) {
+            $payload['profileId'] = $profile;
+        }
+        
         $minimumAmount = $this->mollie
             ->methods
             ->get($method, ['currency' => $currency])

--- a/src/Mollie/GetMolliePayment.php
+++ b/src/Mollie/GetMolliePayment.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment as Contract;
 use Mollie\Api\Resources\Payment;
 
 class GetMolliePayment extends BaseMollieInteraction implements Contract
 {
-    public function execute(string $id, array $parameters = [], ?ProvidesOauthToken $model = null): Payment
+    public function execute(string $id, array $parameters = [], ?ProvidesOauthInformation $model = null): Payment
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->payments->get($id, $parameters + [
-            'testmode' => ! app()->environment('production'),
-        ]);
+        if ($model?->isMollieTestmode()) {
+            $parameters['testmode'] = true;
+        }
+
+        return $this->mollie->payments->get($id, $parameters);
     }
 }

--- a/src/Mollie/GetMolliePayment.php
+++ b/src/Mollie/GetMolliePayment.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment as Contract;
 use Mollie\Api\Resources\Payment;
 
 class GetMolliePayment extends BaseMollieInteraction implements Contract
 {
-    public function execute(string $id, array $parameters = []): Payment
+    public function execute(string $id, array $parameters = [], ?ProvidesOauthToken $model = null): Payment
     {
+        $this->setAccessToken($model);
+
         return $this->mollie->payments->get($id, $parameters);
     }
 }

--- a/src/Mollie/GetMolliePayment.php
+++ b/src/Mollie/GetMolliePayment.php
@@ -14,6 +14,8 @@ class GetMolliePayment extends BaseMollieInteraction implements Contract
     {
         $this->setAccessToken($model);
 
-        return $this->mollie->payments->get($id, $parameters);
+        return $this->mollie->payments->get($id, $parameters + [
+            'testmode' => ! app()->environment('production'),
+        ]);
     }
 }

--- a/src/Mollie/GetMollieRefund.php
+++ b/src/Mollie/GetMollieRefund.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Laravel\Cashier\Mollie\Contracts\GetMollieRefund as Contract;
 use Mollie\Api\Resources\Refund;
@@ -28,11 +28,17 @@ class GetMollieRefund extends BaseMollieInteraction implements Contract
         $this->getMolliePayment = $getMolliePayment;
     }
 
-    public function execute(string $paymentId, string $refundId, ?ProvidesOauthToken $model = null): Refund
+    public function execute(string $paymentId, string $refundId, ?ProvidesOauthInformation $model = null): Refund
     {
         $this->setAccessToken($model);
 
-        $payment = $this->getMolliePayment->execute($paymentId, ['testmode' => ! app()->environment('production')], $model);
+        $payload = [];
+        
+        if ($model?->isMollieTestmode()) {
+            $parameters['testmode'] = true;
+        }
+
+        $payment = $this->getMolliePayment->execute($paymentId, $payload, $model);
 
         return $payment->getRefund($refundId);
     }

--- a/src/Mollie/GetMollieRefund.php
+++ b/src/Mollie/GetMollieRefund.php
@@ -32,7 +32,7 @@ class GetMollieRefund extends BaseMollieInteraction implements Contract
     {
         $this->setAccessToken($model);
 
-        $payment = $this->getMolliePayment->execute($paymentId, [], $model);
+        $payment = $this->getMolliePayment->execute($paymentId, ['testmode' => ! app()->environment('production')], $model);
 
         return $payment->getRefund($refundId);
     }

--- a/src/Mollie/GetMollieRefund.php
+++ b/src/Mollie/GetMollieRefund.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Laravel\Cashier\Mollie\Contracts\GetMollieRefund as Contract;
 use Mollie\Api\Resources\Refund;
 use Mollie\Api\MollieApiClient as Mollie;
 
-class GetMollieRefund implements Contract
+class GetMollieRefund extends BaseMollieInteraction implements Contract
 {
     /**
      * @var \Mollie\Api\MollieApiClient
@@ -27,9 +28,11 @@ class GetMollieRefund implements Contract
         $this->getMolliePayment = $getMolliePayment;
     }
 
-    public function execute(string $paymentId, string $refundId): Refund
+    public function execute(string $paymentId, string $refundId, ?ProvidesOauthToken $model = null): Refund
     {
-        $payment = $this->getMolliePayment->execute($paymentId);
+        $this->setAccessToken($model);
+
+        $payment = $this->getMolliePayment->execute($paymentId, [], $model);
 
         return $payment->getRefund($refundId);
     }

--- a/src/Mollie/UpdateMolliePayment.php
+++ b/src/Mollie/UpdateMolliePayment.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment as Contract;
 use Mollie\Api\Resources\Payment;
 
 class UpdateMolliePayment extends BaseMollieInteraction implements Contract
 {
-    public function execute(Payment $dirtyPayment): Payment
+    public function execute(Payment $dirtyPayment, ?ProvidesOauthToken $model = null): Payment
     {
+        $this->setAccessToken($model);
+
         return $dirtyPayment->update();
     }
 }

--- a/src/Mollie/UpdateMolliePayment.php
+++ b/src/Mollie/UpdateMolliePayment.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Mollie;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment as Contract;
 use Mollie\Api\Resources\Payment;
 
 class UpdateMolliePayment extends BaseMollieInteraction implements Contract
 {
-    public function execute(Payment $dirtyPayment, ?ProvidesOauthToken $model = null): Payment
+    public function execute(Payment $dirtyPayment, ?ProvidesOauthInformation $model = null): Payment
     {
         $this->setAccessToken($model);
 

--- a/src/Order/Contracts/MaximumPayment.php
+++ b/src/Order/Contracts/MaximumPayment.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Order\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Mandate;
 
 interface MaximumPayment
@@ -9,7 +10,8 @@ interface MaximumPayment
     /**
      * @param  \Mollie\Api\Resources\Mandate  $mandate
      * @param $currency
+     * @param  \Laravel\Cashier\Contracts\ProvidesOauthToken|null  $model
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency);
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null);
 }

--- a/src/Order/Contracts/MaximumPayment.php
+++ b/src/Order/Contracts/MaximumPayment.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier\Order\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Mandate;
 
 interface MaximumPayment
@@ -10,8 +10,8 @@ interface MaximumPayment
     /**
      * @param  \Mollie\Api\Resources\Mandate  $mandate
      * @param $currency
-     * @param  \Laravel\Cashier\Contracts\ProvidesOauthToken|null  $model
+     * @param  \Laravel\Cashier\Contracts\ProvidesOauthInformation|null  $model
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null);
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthInformation $model = null);
 }

--- a/src/Order/Contracts/MinimumPayment.php
+++ b/src/Order/Contracts/MinimumPayment.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Order\Contracts;
 
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Mollie\Api\Resources\Mandate;
 
 interface MinimumPayment
@@ -9,7 +10,8 @@ interface MinimumPayment
     /**
      * @param  \Mollie\Api\Resources\Mandate  $mandate
      * @param $currency
+     * @param  \Laravel\Cashier\Contracts\ProvidesOauthToken|null  $model
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency);
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null);
 }

--- a/src/Order/Contracts/MinimumPayment.php
+++ b/src/Order/Contracts/MinimumPayment.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier\Order\Contracts;
 
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Mollie\Api\Resources\Mandate;
 
 interface MinimumPayment
@@ -10,8 +10,8 @@ interface MinimumPayment
     /**
      * @param  \Mollie\Api\Resources\Mandate  $mandate
      * @param $currency
-     * @param  \Laravel\Cashier\Contracts\ProvidesOauthToken|null  $model
+     * @param  \Laravel\Cashier\Contracts\ProvidesOauthInformation|null  $model
      * @return \Money\Money
      */
-    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthToken $model = null);
+    public static function forMollieMandate(Mandate $mandate, $currency, ?ProvidesOauthInformation $model = null);
 }

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Events\BalanceTurnedStale;
 use Laravel\Cashier\Events\OrderCreated;
 use Laravel\Cashier\Events\OrderPaymentFailed;
@@ -706,7 +707,11 @@ class Order extends Model
         if ((int) $this->getTotalDue()->getAmount() > 0) {
             $mandate = $this->owner->mollieMandate();
             $this->guardMandate($mandate);
-            $minimumPaymentAmount = app(MinimumPayment::class)::forMollieMandate($mandate, $this->getCurrency());
+            $minimumPaymentAmount = app(MinimumPayment::class)::forMollieMandate(
+                $mandate,
+                $this->getCurrency(),
+                $this->owner instanceof ProvidesOauthToken ? $this->owner : null
+            );
         } else {
             $minimumPaymentAmount = new Money(0, new Currency($this->getCurrency()));
         }
@@ -725,7 +730,11 @@ class Order extends Model
             $mandate = $this->owner->mollieMandate();
             $this->guardMandate($mandate);
 
-            $maximumPaymentAmount = app(MaximumPayment::class)::forMollieMandate($mandate, $this->getCurrency());
+            $maximumPaymentAmount = app(MaximumPayment::class)::forMollieMandate(
+                $mandate,
+                $this->getCurrency(),
+                $this->owner instanceof ProvidesOauthToken ? $this->owner : null
+            );
         } else {
             $maximumPaymentAmount = new Money(0, new Currency($this->getCurrency()));
         }

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Events\BalanceTurnedStale;
 use Laravel\Cashier\Events\OrderCreated;
 use Laravel\Cashier\Events\OrderPaymentFailed;
@@ -710,7 +710,7 @@ class Order extends Model
             $minimumPaymentAmount = app(MinimumPayment::class)::forMollieMandate(
                 $mandate,
                 $this->getCurrency(),
-                $this->owner instanceof ProvidesOauthToken ? $this->owner : null
+                $this->owner instanceof ProvidesOauthInformation ? $this->owner : null
             );
         } else {
             $minimumPaymentAmount = new Money(0, new Currency($this->getCurrency()));
@@ -733,7 +733,7 @@ class Order extends Model
             $maximumPaymentAmount = app(MaximumPayment::class)::forMollieMandate(
                 $mandate,
                 $this->getCurrency(),
-                $this->owner instanceof ProvidesOauthToken ? $this->owner : null
+                $this->owner instanceof ProvidesOauthInformation ? $this->owner : null
             );
         } else {
             $maximumPaymentAmount = new Money(0, new Currency($this->getCurrency()));

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier;
 
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
 use Laravel\Cashier\Order\ConvertsToMoney;
@@ -142,7 +143,7 @@ class Payment extends Model
 
             /** @var UpdateMolliePayment $updateMolliePayment */
             $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-            $updateMolliePayment->execute($molliePayment);
+            $updateMolliePayment->execute($molliePayment, $owner instanceof ProvidesOauthToken ? $owner : null);
         }
 
         return $newPayment;
@@ -195,6 +196,9 @@ class Payment extends Model
      */
     public function asMolliePayment(): MolliePayment
     {
-        return app()->make(GetMolliePayment::class)->execute($this->mollie_payment_id);
+        return app()->make(GetMolliePayment::class)->execute(
+            $this->mollie_payment_id,
+            $this->owner instanceof ProvidesOauthToken ? $this->owner : null
+        );
     }
 }

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -3,7 +3,7 @@
 namespace Laravel\Cashier;
 
 use Illuminate\Database\Eloquent\Model;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
 use Laravel\Cashier\Order\ConvertsToMoney;
@@ -143,7 +143,7 @@ class Payment extends Model
 
             /** @var UpdateMolliePayment $updateMolliePayment */
             $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-            $updateMolliePayment->execute($molliePayment, $owner instanceof ProvidesOauthToken ? $owner : null);
+            $updateMolliePayment->execute($molliePayment, $owner instanceof ProvidesOauthInformation ? $owner : null);
         }
 
         return $newPayment;
@@ -198,7 +198,7 @@ class Payment extends Model
     {
         return app()->make(GetMolliePayment::class)->execute(
             $this->mollie_payment_id,
-            $this->owner instanceof ProvidesOauthToken ? $this->owner : null
+            $this->owner instanceof ProvidesOauthInformation ? $this->owner : null
         );
     }
 }

--- a/src/Refunds/RefundBuilder.php
+++ b/src/Refunds/RefundBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Refunds;
 
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Contracts\ProvidesOauthToken;
 use Laravel\Cashier\Events\RefundInitiated;
 use Laravel\Cashier\Mollie\Contracts\CreateMollieRefund;
 use Laravel\Cashier\Order\Order;
@@ -93,7 +94,7 @@ class RefundBuilder
                 'value' => money_to_decimal($this->items->getTotal()),
                 'currency' => $currency,
             ],
-        ]);
+        ], $this->order->owner instanceof ProvidesOauthToken ? $this->order->owner : null);
 
         $refundRecord = Cashier::$refundModel::create([
             'owner_type' => $this->order->owner_type,

--- a/src/Refunds/RefundBuilder.php
+++ b/src/Refunds/RefundBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Cashier\Refunds;
 
 use Laravel\Cashier\Cashier;
-use Laravel\Cashier\Contracts\ProvidesOauthToken;
+use Laravel\Cashier\Contracts\ProvidesOauthInformation;
 use Laravel\Cashier\Events\RefundInitiated;
 use Laravel\Cashier\Mollie\Contracts\CreateMollieRefund;
 use Laravel\Cashier\Order\Order;
@@ -94,7 +94,7 @@ class RefundBuilder
                 'value' => money_to_decimal($this->items->getTotal()),
                 'currency' => $currency,
             ],
-        ], $this->order->owner instanceof ProvidesOauthToken ? $this->order->owner : null);
+        ], $this->order->owner instanceof ProvidesOauthInformation ? $this->order->owner : null);
 
         $refundRecord = Cashier::$refundModel::create([
             'owner_type' => $this->order->owner_type,


### PR DESCRIPTION
Now, payment processing with OAuth isn't supported in the package. This could be handy for SaaS apps where organizations manage subscriptions and payments for users. It's a significant change, but I made sure it's backward compatible, so it still functions without OAuth. Hopefully, this can be considered for the next major release.

This PR does depend on [this PR](https://github.com/mollie/mollie-api-php/pull/715) in mollie-api-php