### PR TITLE
Swap Illuminate EventServiceProvider in favour of plain ServiceProvider

### DIFF
--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Laravel\Cashier;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Order\OrderInvoiceSubscriber;
 
 class EventServiceProvider extends ServiceProvider
@@ -15,4 +17,16 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [
         OrderInvoiceSubscriber::class,
     ];
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @param Dispatcher $events
+     * @return void
+     */
+    public function boot(Dispatcher $events)
+    {
+        collect($this->subscribe)
+            ->each(fn(string $subscriber) => $events->subscribe($subscriber));
+    }
 }

--- a/src/Order/OrderInvoiceSubscriber.php
+++ b/src/Order/OrderInvoiceSubscriber.php
@@ -32,14 +32,9 @@ class OrderInvoiceSubscriber
      */
     public function subscribe($events)
     {
-        $events->listen(
-            OrderPaymentPaid::class,
-            self::class.'@handleOrderPaymentPaid'
-        );
-
-        $events->listen(
-            FirstPaymentPaid::class,
-            self::class.'@handleFirstPaymentPaid'
-        );
+        return [
+            OrderPaymentPaid::class => 'handleOrderPaymentPaid',
+            FirstPaymentPaid::class => 'handleFirstPaymentPaid',
+        ];
     }
 }


### PR DESCRIPTION
Solves #247 

**Explanation**
According to the issue ticket, extending the Illuminate `EventServiceProvider` may cause listeners to get registered twice somehow. I haven't verified this, but 

**Fix**
This patch swaps out the `EventServiceProvider` and adopts the plain `ServiceProvider`, so all the core event stuff doesn't accidentally gets mixed in.