### PR TITLE
Add a public getter method for retrieving the refund for unused time

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -613,6 +613,28 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
     }
 
     /**
+     * Gets the amount to be refunded for the subscription's unused time.
+     *
+     * @param  \Carbon\Carbon|null  $now
+     * @return \Money\Money
+     */
+    public function getReimburseAmountForUnusedTime(?Carbon $now = null): ?Money
+    {
+        $now = $now ?: now();
+
+        if ($this->onTrial()) {
+            return null;
+        }
+        if (round($this->getCycleLeftAttribute($now), 5) == 0) {
+            return null;
+        }
+
+        return $this->reimbursableAmount()
+            ->negative()
+            ->multiply(sprintf('%.8F', $this->getCycleLeftAttribute($now)));
+    }
+
+    /**
      * Handle a failed payment.
      *
      * @param  \Laravel\Cashier\Order\OrderItem  $item


### PR DESCRIPTION
Fixes #252 

As mentioned in #252, the other option is to make the method ```reimbursableAmount()``` public. Please do let me know what you think the best option is.