### PR TITLE
Fix: Correct import to resolve TypeError in RefundItemCollection

### DIFF
--- a/src/Refunds/RefundItemCollection.php
+++ b/src/Refunds/RefundItemCollection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Cashier\Refunds;
 
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Collection;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Order\OrderItem;
 use Laravel\Cashier\Order\OrderItemCollection;


### PR DESCRIPTION
Got this TypeError while unserializing a `RefundProcessed` event from a queue:

```
TypeError: Illuminate\Database\Eloquent\Relations\HasMany::match(): Argument #2 ($results) must be of type Illuminate\Database\Eloquent\Collection, Laravel\Cashier\Refunds\RefundItemCollection given, called in /srv/app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php on line 785 and defined in /srv/app/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/HasMany.php:60
```

The error occurred because `RefundItemCollection` extended `Illuminate\Support\Collection` instead of `Illuminate\Database\Eloquent\Collection`, leading to a type mismatch in Eloquent relationships that require the latter.

This change fixes the issue by extending from the correct `Eloquent\Collection`.