### PR TITLE
feat: Add identifier for order items

### DIFF
--- a/database/migrations/alter_order_items_add_identifier.php.stub
+++ b/database/migrations/alter_order_items_add_identifier.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $table) {
+            $table->string('identifier')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::hasColumn('order_items', 'identifier', function (Blueprint $table) {
+            $table->dropColumn('identifier');
+        });
+    }
+};

--- a/docs/04-charges.md
+++ b/docs/04-charges.md
@@ -25,6 +25,7 @@ $user = App\User::find(1);
 $item = new \Laravel\Cashier\Charge\ChargeItemBuilder($user);
 $item->unitPrice(money(100,'EUR')); //1 EUR
 $item->description('Test Item 1');
+$item->identifier('test-item-id-1')
 $chargeItem = $item->make();
 
 $item2 = new \Laravel\Cashier\Charge\ChargeItemBuilder($user);

--- a/src/Charge/ChargeItem.php
+++ b/src/Charge/ChargeItem.php
@@ -24,12 +24,15 @@ class ChargeItem
 
     protected int $roundingMode;
 
+    protected ?string $identifier;
+
     public function __construct(
         Model $owner,
         Money $unitPrice,
         string $description,
         int $quantity = 1,
         float $taxPercentage = 0,
+        ?string $identifier = null,
         int $roundingMode = Money::ROUND_HALF_UP
     ) {
         $this->owner = $owner;
@@ -38,16 +41,18 @@ class ChargeItem
         $this->quantity = $quantity;
         $this->taxPercentage = $taxPercentage;
         $this->roundingMode = $roundingMode;
+        $this->identifier = $identifier;
     }
 
     public function toFirstPaymentAction(): FirstPaymentAction
     {
         $item = new AddGenericOrderItem(
-            $this->owner,
-            $this->unitPrice,
-            $this->quantity,
-            $this->description,
-            $this->roundingMode
+            owner: $this->owner,
+            unitPrice: $this->unitPrice,
+            quantity: $this->quantity,
+            description: $this->description,
+            roundingMode: $this->roundingMode,
+            identifier: $this->identifier
         );
 
         $item->withTaxPercentage($this->taxPercentage);

--- a/src/Charge/ChargeItemBuilder.php
+++ b/src/Charge/ChargeItemBuilder.php
@@ -17,6 +17,8 @@ class ChargeItemBuilder
 
     protected float $taxPercentage;
 
+    protected ?string $identifier = null;
+
     public function __construct(Model $owner)
     {
         $this->owner = $owner;
@@ -51,14 +53,22 @@ class ChargeItemBuilder
         return $this;
     }
 
+    public function identifier(string $identifier): ChargeItemBuilder
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
     public function make(): ChargeItem
     {
         return new ChargeItem(
-            $this->owner,
-            $this->unitPrice,
-            $this->description,
-            $this->quantity,
-            $this->taxPercentage
+            owner: $this->owner,
+            unitPrice: $this->unitPrice,
+            description: $this->description,
+            quantity: $this->quantity,
+            taxPercentage: $this->taxPercentage,
+            identifier: $this->identifier,
         );
     }
 }

--- a/src/FirstPayment/Actions/AddBalance.php
+++ b/src/FirstPayment/Actions/AddBalance.php
@@ -33,4 +33,23 @@ class AddBalance extends AddGenericOrderItem
 
         return parent::execute();
     }
+
+    /**
+     * @param  array  $payload
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @return self
+     */
+    public static function createFromPayload(array $payload, Model $owner)
+    {
+        $taxPercentage = $payload['taxPercentage'] ?? 0;
+        $quantity = $payload['quantity'] ?? 1;
+        $unit_price = $payload['subtotal'] ?? $payload['unit_price'];
+
+        return (new self(
+            owner: $owner,
+            subtotal: mollie_array_to_money($unit_price),
+            quantity: $quantity,
+            description: $payload['description'],
+        ))->withTaxPercentage($taxPercentage);
+    }
 }

--- a/src/FirstPayment/Actions/AddGenericOrderItem.php
+++ b/src/FirstPayment/Actions/AddGenericOrderItem.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\FirstPayment\Actions;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 use Money\Money;
 
 class AddGenericOrderItem extends BaseAction
@@ -14,10 +15,17 @@ class AddGenericOrderItem extends BaseAction
      * @param  \Money\Money  $unitPrice
      * @param  int  $quantity
      * @param  string  $description
+     * @param  ?string  $identifier
      * @param  int  $roundingMode
      */
-    public function __construct(Model $owner, Money $unitPrice, int $quantity, string $description, int $roundingMode = Money::ROUND_HALF_UP)
-    {
+    public function __construct(
+        Model $owner,
+        Money $unitPrice,
+        int $quantity,
+        string $description,
+        int $roundingMode = Money::ROUND_HALF_UP,
+        ?string $identifier = null
+    ) {
         $this->owner = $owner;
         $this->taxPercentage = $this->owner->taxPercentage();
         $this->unitPrice = $unitPrice;
@@ -25,6 +33,7 @@ class AddGenericOrderItem extends BaseAction
         $this->currency = $unitPrice->getCurrency()->getCode();
         $this->description = $description;
         $this->roundingMode = $roundingMode;
+        $this->identifier = $identifier;
     }
 
     /**
@@ -37,12 +46,14 @@ class AddGenericOrderItem extends BaseAction
         $taxPercentage = $payload['taxPercentage'] ?? 0;
         $quantity = $payload['quantity'] ?? 1;
         $unit_price = $payload['subtotal'] ?? $payload['unit_price'];
+        $identifier = $payload['identifier'] ?? null;
 
-        return (new static(
-            $owner,
-            mollie_array_to_money($unit_price),
-            $quantity,
-            $payload['description']
+        return (new self(
+            owner: $owner,
+            unitPrice: mollie_array_to_money($unit_price),
+            quantity: $quantity,
+            description: $payload['description'],
+            identifier: $identifier,
         ))->withTaxPercentage($taxPercentage);
     }
 
@@ -57,6 +68,7 @@ class AddGenericOrderItem extends BaseAction
             'unit_price' => money_to_mollie_array($this->getUnitPrice()),
             'quantity' => $this->getQuantity(),
             'taxPercentage' => $this->getTaxPercentage(),
+            'identifier' => $this->identifier,
         ];
     }
 
@@ -74,6 +86,7 @@ class AddGenericOrderItem extends BaseAction
             'unit_price' => $this->getUnitPrice()->getAmount(),
             'tax_percentage' => $this->getTaxPercentage(),
             'quantity' => $this->getQuantity(),
+            'identifier' => $this->identifier,
         ])->toCollection();
     }
 

--- a/src/FirstPayment/Actions/BaseAction.php
+++ b/src/FirstPayment/Actions/BaseAction.php
@@ -29,6 +29,9 @@ abstract class BaseAction
     /** @var int */
     protected $roundingMode = Money::ROUND_HALF_UP;
 
+    /** @var ?string */
+    protected $identifier = null;
+
     /**
      * Rebuild the Action from a payload.
      *

--- a/tests/FirstPayment/Actions/AddBalanceTest.php
+++ b/tests/FirstPayment/Actions/AddBalanceTest.php
@@ -33,6 +33,7 @@ class AddBalanceTest extends BaseTestCase
             'taxPercentage' => 0,
             'description' => 'Adding some test balance',
             'quantity' => 1,
+            'identifier' => null,
         ], $payload);
     }
 

--- a/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
+++ b/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
@@ -33,6 +33,7 @@ class AddGenericOrderItemTest extends BaseTestCase
             'taxPercentage' => 20,
             'description' => 'Adding a test order item',
             'quantity' => 1,
+            'identifier' => null,
         ], $payload);
     }
 


### PR DESCRIPTION
The use case: When creating an order with items, there is no reference to the order item other than a description:

```php
$item = new \Laravel\Cashier\Charge\ChargeItemBuilder($user);
$item->unitPrice(money(100,'EUR')); //1 EUR
$item->description('Test Item 1');
$chargeItem = $item->make();

$result = $user->newCharge()
    ->addItem($chargeItem)
    ->setRedirectUrl('https://www.example.com')
    ->create();
```

To make it easier to link an order item back to a table containing products for example, I would like to introduce the optional `$item->identifier();` method to add a local ID such a product UUID to the order item.