### PR TITLE
feat: Add metadata field

### DIFF
--- a/database/migrations/alter_order_items_add_metadata.php.stub
+++ b/database/migrations/alter_order_items_add_metadata.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterOrderItemsAddMetadata extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->json('metadata')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::hasColumn('order_items', 'identifier', function (Blueprint $table) {
+            $table->dropColumn('metadata');
+        });
+    }
+};

--- a/docs/04-charges.md
+++ b/docs/04-charges.md
@@ -25,6 +25,7 @@ $user = App\User::find(1);
 $item = new \Laravel\Cashier\Charge\ChargeItemBuilder($user);
 $item->unitPrice(money(100,'EUR')); //1 EUR
 $item->description('Test Item 1');
+$item->metadata(['isbn' => '123', 'sku' => 'abc' ])
 $chargeItem = $item->make();
 
 $item2 = new \Laravel\Cashier\Charge\ChargeItemBuilder($user);

--- a/src/Charge/ChargeItem.php
+++ b/src/Charge/ChargeItem.php
@@ -24,12 +24,15 @@ class ChargeItem
 
     protected int $roundingMode;
 
+    protected ?string $metadata;
+
     public function __construct(
         Model $owner,
         Money $unitPrice,
         string $description,
         int $quantity = 1,
         float $taxPercentage = 0,
+        ?string $metadata = null,
         int $roundingMode = Money::ROUND_HALF_UP
     ) {
         $this->owner = $owner;
@@ -38,16 +41,18 @@ class ChargeItem
         $this->quantity = $quantity;
         $this->taxPercentage = $taxPercentage;
         $this->roundingMode = $roundingMode;
+        $this->metadata = $metadata;
     }
 
     public function toFirstPaymentAction(): FirstPaymentAction
     {
         $item = new AddGenericOrderItem(
-            $this->owner,
-            $this->unitPrice,
-            $this->quantity,
-            $this->description,
-            $this->roundingMode
+            owner: $this->owner,
+            unitPrice: $this->unitPrice,
+            quantity: $this->quantity,
+            description: $this->description,
+            roundingMode: $this->roundingMode,
+            metadata: $this->metadata
         );
 
         $item->withTaxPercentage($this->taxPercentage);

--- a/src/Charge/ChargeItemBuilder.php
+++ b/src/Charge/ChargeItemBuilder.php
@@ -17,6 +17,8 @@ class ChargeItemBuilder
 
     protected float $taxPercentage;
 
+    protected ?string $metadata = null;
+
     public function __construct(Model $owner)
     {
         $this->owner = $owner;
@@ -51,14 +53,22 @@ class ChargeItemBuilder
         return $this;
     }
 
+    public function metadata(array $metadata): ChargeItemBuilder
+    {
+        $this->metadata = json_encode($metadata);
+
+        return $this;
+    }
+
     public function make(): ChargeItem
     {
         return new ChargeItem(
-            $this->owner,
-            $this->unitPrice,
-            $this->description,
-            $this->quantity,
-            $this->taxPercentage
+            owner: $this->owner,
+            unitPrice: $this->unitPrice,
+            description: $this->description,
+            quantity: $this->quantity,
+            taxPercentage: $this->taxPercentage,
+            metadata: $this->metadata,
         );
     }
 }

--- a/src/Console/Commands/CashierInstall.php
+++ b/src/Console/Commands/CashierInstall.php
@@ -40,6 +40,7 @@ class CashierInstall extends Command
 
         $this->comment('Publishing Cashier configuration files...');
         $this->callSilent('vendor:publish', ['--tag' => 'cashier-configs']);
+        $this->publishLocalMigrations();
 
         if ($this->option('template')) {
             $this->callSilent('vendor:publish', ['--tag' => 'cashier-views']);
@@ -56,5 +57,18 @@ class CashierInstall extends Command
         }
 
         $this->info('Cashier was installed successfully.');
+    }
+
+    /**
+     * Copy local migrations to the application.
+     */
+    private function publishLocalMigrations(): void
+    {
+        if (! class_exists('AlterOrderItemsAddIdentifier')) {
+            copy(
+                __DIR__.'/../../../database/migrations/alter_order_items_add_metadata.php.stub',
+                database_path('migrations/'.date('Y_m_d_His', time()).'_alter_order_items_add_metadata.php')
+            );
+        }
     }
 }

--- a/src/FirstPayment/Actions/AddBalance.php
+++ b/src/FirstPayment/Actions/AddBalance.php
@@ -33,4 +33,23 @@ class AddBalance extends AddGenericOrderItem
 
         return parent::execute();
     }
+
+    /**
+     * @param  array  $payload
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @return self
+     */
+    public static function createFromPayload(array $payload, Model $owner)
+    {
+        $taxPercentage = $payload['taxPercentage'] ?? 0;
+        $quantity = $payload['quantity'] ?? 1;
+        $unit_price = $payload['subtotal'] ?? $payload['unit_price'];
+
+        return (new self(
+            owner: $owner,
+            subtotal: mollie_array_to_money($unit_price),
+            quantity: $quantity,
+            description: $payload['description'],
+        ))->withTaxPercentage($taxPercentage);
+    }
 }

--- a/src/FirstPayment/Actions/BaseAction.php
+++ b/src/FirstPayment/Actions/BaseAction.php
@@ -29,6 +29,9 @@ abstract class BaseAction
     /** @var int */
     protected $roundingMode = Money::ROUND_HALF_UP;
 
+    /** @var ?string */
+    protected ?string $metadata;
+
     /**
      * Rebuild the Action from a payload.
      *

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -94,6 +94,10 @@ abstract class BaseTestCase extends TestCase
                         'class' => '\CreateRefundsTable',
                         'file_path' => $migrations_dir . '/create_refunds_table.php.stub',
                     ],
+                    [
+                        'class' => '\AlterOrderItemsAddIdentifier',
+                        'file_path' => $migrations_dir . '/alter_order_items_add_identifier.php.stub',
+                    ],
                 ]
             )
         );

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -95,8 +95,8 @@ abstract class BaseTestCase extends TestCase
                         'file_path' => $migrations_dir . '/create_refunds_table.php.stub',
                     ],
                     [
-                        'class' => '\AlterOrderItemsAddIdentifier',
-                        'file_path' => $migrations_dir . '/alter_order_items_add_identifier.php.stub',
+                        'class' => '\AlterOrderItemsAddMetadata',
+                        'file_path' => $migrations_dir . '/alter_order_items_add_metadata.php.stub',
                     ],
                 ]
             )

--- a/tests/FirstPayment/Actions/AddBalanceTest.php
+++ b/tests/FirstPayment/Actions/AddBalanceTest.php
@@ -33,6 +33,7 @@ class AddBalanceTest extends BaseTestCase
             'taxPercentage' => 0,
             'description' => 'Adding some test balance',
             'quantity' => 1,
+            'metadata' => null,
         ], $payload);
     }
 

--- a/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
+++ b/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
@@ -33,6 +33,7 @@ class AddGenericOrderItemTest extends BaseTestCase
             'taxPercentage' => 20,
             'description' => 'Adding a test order item',
             'quantity' => 1,
+            'metadata' => null,
         ], $payload);
     }
 


### PR DESCRIPTION
A cleaner version of #271:

The use case: When creating an order with items, you cannot add any extra data to an order-item other than the price and description:

```
$item = new \Laravel\Cashier\Charge\ChargeItemBuilder($user);
$item->unitPrice(money(100,'EUR'));
$item->description('Test Item 1');
$chargeItem = $item->make();
```

I would like to introduce a metadata field:

```
$item->metadata(['product_id' => 1, 'isbn' => 1234]);
```

This allows a user to add a reference to the original product for example, to update stock, or create a sales order.
