### PR TITLE
feat: Add php-cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,12 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR2' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Before submitting a pull request:
 
 If the project maintainer has any additional requirements, you will find them listed here.
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The project includes [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer), you can run `composer fix` to fix the coding style.
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "nesbot/carbon": "^2.72|^3.0"
   },
   "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.66",
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
     "orchestra/testbench": "^8.0|^9.0",
@@ -73,6 +74,7 @@
   "minimum-stability": "stable",
   "prefer-stable": true,
   "scripts": {
-    "test": "./vendor/bin/phpunit tests"
+    "test": "./vendor/bin/phpunit tests",
+    "fix": "./vendor/bin/php-cs-fixer fix"
   }
 }

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Cashier;
 
-
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Order\OrderInvoiceSubscriber;
@@ -27,6 +26,6 @@ class EventServiceProvider extends ServiceProvider
     public function boot(Dispatcher $events)
     {
         collect($this->subscribe)
-            ->each(fn(string $subscriber) => $events->subscribe($subscriber));
+            ->each(fn (string $subscriber) => $events->subscribe($subscriber));
     }
 }

--- a/src/Plan/DefaultIntervalGenerator.php
+++ b/src/Plan/DefaultIntervalGenerator.php
@@ -39,7 +39,8 @@ class DefaultIntervalGenerator extends BaseIntervalGenerator implements Interval
     /**
      * @return string
      */
-    public function interval() {
+    public function interval()
+    {
         return $this->interval;
     }
 

--- a/src/Refunds/Refund.php
+++ b/src/Refunds/Refund.php
@@ -92,8 +92,7 @@ class Refund extends Model
             $refundItems->each(function (RefundItem $refundItem) {
                 $originalOrderItem = $refundItem->originalOrderItem;
 
-                if( $originalOrderItem && method_exists($originalOrderItem, 'handlePaymentRefunded') )
-                {
+                if ($originalOrderItem && method_exists($originalOrderItem, 'handlePaymentRefunded')) {
                     $originalOrderItem->handlePaymentRefunded($refundItem);
                 }
             });


### PR DESCRIPTION
In order to make it easy to follow the coding standards, it might be handy to include [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer). 

I have added a config file with the PSR2 ruleset, and a `composer fix` command to run it.