### PR TITLE
Added dedicated command for syncing subscription plan prices

### DIFF
--- a/docs/02-subscriptions.md
+++ b/docs/02-subscriptions.md
@@ -1,5 +1,19 @@
 # Subscriptions
 
+## Configuring subscription plans
+
+You may configure subscription plans in `config/cashier_plans.php`.
+
+Note that any already scheduled order items will not be affected by the plan change.
+
+If you want to see your plan changes reflected immediately, run the `SyncSubscriptionPlans` command using
+
+```bash
+php artisan cashier:sync-plans
+```
+
+This will update the scheduled order items to match the new plan configuration.
+
 ## Creating subscriptions
 
 To create a subscription, first retrieve an instance of your billable model, which typically will be an instance of

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Console\Commands\CashierInstall;
 use Laravel\Cashier\Console\Commands\CashierRun;
 use Laravel\Cashier\Console\Commands\CashierUpdate;
+use Laravel\Cashier\Console\Commands\SyncSubscriptionPrices;
 use Laravel\Cashier\Coupon\ConfigCouponRepository;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
 use Laravel\Cashier\Mollie\RegistersMollieInteractions;
@@ -70,6 +71,7 @@ class CashierServiceProvider extends ServiceProvider
                 CashierInstall::class,
                 CashierRun::class,
                 CashierUpdate::class,
+                SyncSubscriptionPrices::class,
             ]);
         }
     }

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Console\Commands\CashierInstall;
 use Laravel\Cashier\Console\Commands\CashierRun;
 use Laravel\Cashier\Console\Commands\CashierUpdate;
-use Laravel\Cashier\Console\Commands\SyncSubscriptionPrices;
+use Laravel\Cashier\Console\Commands\SyncSubscriptionPlans;
 use Laravel\Cashier\Coupon\ConfigCouponRepository;
 use Laravel\Cashier\Coupon\Contracts\CouponRepository;
 use Laravel\Cashier\Mollie\RegistersMollieInteractions;
@@ -71,7 +71,7 @@ class CashierServiceProvider extends ServiceProvider
                 CashierInstall::class,
                 CashierRun::class,
                 CashierUpdate::class,
-                SyncSubscriptionPrices::class,
+                SyncSubscriptionPlans::class,
             ]);
         }
     }

--- a/src/Console/Commands/SyncSubscriptionPrices.php
+++ b/src/Console/Commands/SyncSubscriptionPrices.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Laravel\Cashier\Console\Commands;
+
+use Illuminate\Console\Command;
+use Laravel\Cashier\Order\OrderItem;
+use Laravel\Cashier\Plan\Contracts\PlanRepository;
+use Laravel\Cashier\Plan\Plan;
+use Laravel\Cashier\Subscription;
+
+class SyncSubscriptionPrices extends Command
+{
+    /**
+     * @var PlanRepository
+     */
+    protected $planRepository;
+
+    public function __construct(PlanRepository $planRepository)
+    {
+        parent::__construct();
+        $this->planRepository = $planRepository;
+    }
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cashier:sync-subscription-prices';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update prices of scheduled order items to match their current subscription plan prices';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $query = OrderItem::query()
+            ->with('orderable')
+            ->whereNull('processed_at')
+            ->whereNotNull('orderable_type') // Support default model overrides
+            ->whereNotNull('orderable_id');
+
+        $updated = 0;
+
+        $query->chunk(100, function ($items) use (&$updated) {
+            foreach ($items as $item) {
+                
+                // Skip if not a subscription order item
+                if (!($item->orderable instanceof Subscription)) {
+                    continue;
+                }
+
+                /** @var Subscription $subscription */
+                $subscription = $item->orderable;
+                
+                // Get the current plan price
+                /** @var Plan $plan */
+                $plan = $this->planRepository->findOrFail($subscription->plan);
+                $planAmount = $plan->amount()->getAmount();
+                $planCurrency = $plan->amount()->getCurrency()->getCode();
+
+                // Check if either the price or currency needs updating
+                if ($item->unit_price !== $planAmount || $item->currency !== $planCurrency) {
+                    $item->update([
+                        'unit_price' => $planAmount,
+                        'currency' => $planCurrency,
+                    ]);
+                    
+                    $updated++;
+                    
+                    $this->info(sprintf(
+                        'Updated price for order item #%d (Subscription #%d) from %d to %d %s',
+                        $item->id,
+                        $subscription->id,
+                        $item->unit_price,
+                        $planAmount,
+                        $planCurrency,
+                    ));
+                }
+            }
+        });
+
+        $this->info("Updated prices for {$updated} order items.");
+
+        return 0;
+    }
+}


### PR DESCRIPTION
As reported in #275 , price changes on plans are not reflected on subscription order items that were already scheduled.

Any future to-be scheduled order items are not affected, these already are reflecting the updated prices.

This PR introduces a dedicated command to sync prices on scheduled order items, using the latest Plan prices. This command typically should be run directly after a price change.

The command can be run using:

```bash
php artisan cashier:sync-subscription-prices
```