### PR TITLE
Simplify $this->valid() in Subscription.php

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -147,7 +147,7 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
      */
     public function valid()
     {
-        return $this->active() || $this->onTrial() || $this->onGracePeriod();
+        return $this->active();
     }
 
     /**


### PR DESCRIPTION
Simplify the valid() method for readability.

onTrial() and onGracePeriod() are already checked in active(), so no need to check them again.

Is there any reason why ->valid() and ->active can't be consolidated into one method (in v3 maybe?)

EDIT: And thanks for a great package, @sandervanhooft!