### PR TITLE
fix: Use explicit nullable types in parameters

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -420,10 +420,10 @@ trait Billable
      * @param $orderId
      * @param  null|array  $data
      * @param  string  $view
-     * @param  \Dompdf\Options  $options
+     * @param  \Dompdf\Options|null  $options
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW, Options $options = null)
+    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW, ?Options $options = null)
     {
         /** @var Order $order */
         $order = $this->orders()->where('id', $orderId)->firstOrFail();

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -468,10 +468,10 @@ class Subscription extends Model implements InteractsWithOrderItems, Preprocesse
      * @param  Carbon|null  $process_at
      * @param  array  $item_overrides
      * @param  bool  $fill_link Indicates whether scheduled_order_item_id field should be filled to point to the newly scheduled order item
-     * @param  \Laravel\Cashier\Plan\Contracts\Plan  $plan
+     * @param  \Laravel\Cashier\Plan\Contracts\Plan|null  $plan
      * @return \Illuminate\Database\Eloquent\Model|\Laravel\Cashier\Order\OrderItem
      */
-    public function scheduleNewOrderItemAt(Carbon $process_at, $item_overrides = [], $fill_link = true, Plan $plan = null)
+    public function scheduleNewOrderItemAt(Carbon $process_at, $item_overrides = [], $fill_link = true, ?Plan $plan = null)
     {
         if ($this->scheduled_order_item_id) {
             throw new LogicException('Cannot schedule a new subscription order item if there is already one scheduled.');


### PR DESCRIPTION
This fixes a deprecation warning in PHP 8.4.11.