### PR TITLE
fix: PHP 8.4 deprecation - use explicit nullable type in downloadInvoice()

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -423,7 +423,7 @@ trait Billable
      * @param  \Dompdf\Options  $options
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW, Options $options = null)
+    public function downloadInvoice($orderId, $data = [], $view = Invoice::DEFAULT_VIEW, ?Options $options = null)
     {
         /** @var Order $order */
         $order = $this->orders()->where('id', $orderId)->firstOrFail();


### PR DESCRIPTION
## Summary

This PR fixes a PHP 8.4 deprecation warning by using explicit nullable type declaration.

## Problem

PHP 8.4 deprecated implicit nullable parameter declarations. The following warning is triggered: