### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,14 +15,21 @@ jobs:
             matrix:
                 os: [ ubuntu-latest ]
                 php: [ 8.4, 8.3, 8.2, 8.1 ]
-                laravel: [ 12.*, 11.*, 10.* ]
+                laravel: [ 13.*, 12.*, 11.*, 10.* ]
                 dependency-version: [ prefer-stable ]
+                exclude:
+                    - php: 8.1
+                      laravel: 13.*
+                    - php: 8.2
+                      laravel: 13.*
+                    - php: 8.1
+                      laravel: 12.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
     "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-    "phpunit/phpunit": "^10.0|^11.5|^12.0"
+    "phpunit/phpunit": "^10.0|^11.5"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     "ext-json": "*",
     "ext-intl": "*",
     "dompdf/dompdf": "^2.0|^3.0",
-    "illuminate/database": "^10|^11|^12",
-    "illuminate/support": "^10|^11|^12",
+    "illuminate/database": "^10|^11|^12|^13",
+    "illuminate/support": "^10|^11|^12|^13",
     "mollie/laravel-mollie": "^3.0",
     "mollie/mollie-api-php": "^2.76",
     "moneyphp/money": "^4.1",
@@ -44,8 +44,8 @@
   "require-dev": {
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
-    "orchestra/testbench": "^8.0|^9.0|^10.0",
-    "phpunit/phpunit": "^10.0|^11.5"
+    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+    "phpunit/phpunit": "^10.0|^11.5|^12.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
Laravel 13 was released and the illuminate constraints need widening. This also updates the dev tooling to match.

- `illuminate/database` and `illuminate/support` now accept `^13`
- `orchestra/testbench` gets `^11.0` for Laravel 13 test support
- CI matrix includes Laravel 13 with PHP version excludes (L13 needs 8.3+, L12 needs 8.2+)
- `actions/checkout` bumped from v3 to v4

PHPUnit stays at `^10.0|^11.5` (no `^12.0`). PHPUnit 12 dropped support for `@test` and `@group` docblock annotations, which the test suite uses throughout. Adding PHPUnit 12 support means converting all annotations to PHP 8 attributes — better done separately.

No code changes — just dependency constraints and CI.

Closes #311, supersedes #312.