### PR TITLE
Upgrade to mollie/laravel-mollie v4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,25 +7,46 @@ on:
         - cron: '0 0 * * *'
 
 jobs:
-    tests:
-
+    resolve:
+        name: Resolve P${{ matrix.php }} - L${{ matrix.laravel }}
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                php: [ 8.4, 8.3, 8.2 ]
+                laravel: [ 13.*, 12.*, 11.* ]
+                exclude:
+                    - php: 8.2
+                      laravel: 13.*
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: curl, dom, intl, json, libxml, mbstring, openssl, zip
+                  tools: composer:v2
+
+            - name: Check dependency resolution
+              run: |
+                  composer require illuminate/support:${{ matrix.laravel }} --no-update --no-interaction
+                  composer update --prefer-stable --prefer-dist --no-interaction --no-progress --dry-run
+
+    tests:
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+        runs-on: ubuntu-latest
+        needs: resolve
         strategy:
             fail-fast: true
             matrix:
-                os: [ ubuntu-latest ]
-                php: [ 8.4, 8.3, 8.2, 8.1 ]
-                laravel: [ 13.*, 12.*, 11.*, 10.* ]
+                php: [ 8.4, 8.3, 8.2 ]
+                laravel: [ 13.*, 12.*, 11.* ]
                 dependency-version: [ prefer-stable ]
                 exclude:
-                    - php: 8.1
-                      laravel: 13.*
                     - php: 8.2
                       laravel: 13.*
-                    - php: 8.1
-                      laravel: 12.*
-
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
@@ -41,7 +62,30 @@ jobs:
 
             - name: Install dependencies
               run: |
+                  composer require illuminate/support:${{ matrix.laravel }} --no-update --no-interaction
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
+
+            - name: Execute tests
+              run: vendor/bin/phpunit --coverage-text
+
+    prefer-lowest:
+        name: Prefer lowest (P8.2)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.2
+                  extensions: curl, dom, intl, json, libxml, mbstring, openssl, zip
+                  tools: composer:v2
+                  coverage: xdebug
+
+            - name: Install lowest dependencies
+              run: |
+                  composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction --no-progress
 
             - name: Execute tests
               run: vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -30,22 +30,21 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-json": "*",
     "ext-intl": "*",
     "dompdf/dompdf": "^2.0|^3.0",
-    "illuminate/database": "^10|^11|^12|^13",
-    "illuminate/support": "^10|^11|^12|^13",
-    "mollie/laravel-mollie": "^3.0",
-    "mollie/mollie-api-php": "^2.76",
+    "illuminate/database": "^11|^12|^13",
+    "illuminate/support": "^11|^12|^13",
+    "mollie/laravel-mollie": "^4.0",
     "moneyphp/money": "^4.1",
     "nesbot/carbon": "^2.72|^3.0"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
-    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-    "phpunit/phpunit": "^10.0|^11.5"
+    "orchestra/testbench": "^9.0|^10.0|^11.0",
+    "phpunit/phpunit": "^10.5|^11.5|^12.0|^13.0"
   },
   "autoload": {
     "files": [

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "require-dev": {
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
-    "orchestra/testbench": "^9.0|^10.0|^11.0",
+    "orchestra/testbench": "^9.6|^10.0|^11.0",
     "phpunit/phpunit": "^10.5|^11.5|^12.0|^13.0"
   },
   "autoload": {

--- a/src/FirstPayment/FirstPaymentBuilder.php
+++ b/src/FirstPayment/FirstPaymentBuilder.php
@@ -102,7 +102,7 @@ class FirstPaymentBuilder
     public function getMolliePayload()
     {
         return array_filter(array_merge([
-            'sequenceType' => SequenceType::SEQUENCETYPE_FIRST,
+            'sequenceType' => SequenceType::FIRST,
             'method' => $this->method,
             'customerId' => $this->owner->asMollieCustomer()->id,
             'locale' => Cashier::getLocale($this->owner),

--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -78,10 +78,10 @@ class AftercareWebhookController extends BaseWebhookController
             $mollieRefund = $this->extractMatchingMollieRefundForLocalRefund($localRefund, $mollieRefunds);
 
             if ($mollieRefund) {
-                if ($mollieRefund->isTransferred() && $localRefund->mollie_refund_status !== RefundStatus::STATUS_REFUNDED) {
+                if ($mollieRefund->isTransferred() && $localRefund->mollie_refund_status !== RefundStatus::REFUNDED) {
                     $localRefund->handleProcessed();
                     $paymentAmountRefundedHasChanged = true;
-                } elseif ($mollieRefund->isFailed() && $localRefund->mollie_refund_status !== RefundStatus::STATUS_FAILED) {
+                } elseif ($mollieRefund->isFailed() && $localRefund->mollie_refund_status !== RefundStatus::FAILED) {
                     $localRefund->handleFailed();
                     $paymentAmountRefundedHasChanged = true;
                 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -26,7 +26,7 @@ class WebhookController extends BaseWebhookController
 
             if ($order && $order->mollie_payment_status !== $payment->status) {
                 switch ($payment->status) {
-                    case PaymentStatus::STATUS_PAID:
+                    case PaymentStatus::PAID:
                         $order->handlePaymentPaid($payment);
                         $payment->webhookUrl = route('webhooks.mollie.aftercare');
 
@@ -35,7 +35,7 @@ class WebhookController extends BaseWebhookController
                         $updateMolliePayment->execute($payment);
 
                         break;
-                    case PaymentStatus::STATUS_FAILED:
+                    case PaymentStatus::FAILED:
                         $order->handlePaymentFailed($payment);
 
                         break;

--- a/src/MandatedPayment/MandatedPaymentBuilder.php
+++ b/src/MandatedPayment/MandatedPaymentBuilder.php
@@ -67,7 +67,7 @@ class MandatedPaymentBuilder
         $overrides = array_merge($this->overrides, $overrides);
 
         return array_filter(array_merge([
-            'sequenceType' => SequenceType::SEQUENCETYPE_RECURRING,
+            'sequenceType' => SequenceType::RECURRING,
             'mandateId' => $this->owner->mollieMandateId(),
             'customerId' => $this->owner->mollieCustomerId(),
             'locale' => Cashier::getLocale($this->owner),

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -396,7 +396,7 @@ class Order extends Model
     public function scopePaid($query)
     {
         return $this
-            ->scopePaymentStatus($query, PaymentStatus::STATUS_PAID)
+            ->scopePaymentStatus($query, PaymentStatus::PAID)
             ->orWhere('total_due', '=', 0);
     }
 

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -137,7 +137,7 @@ class Payment extends Model
 
         $newPayment = static::createFromMolliePayment($molliePayment, $owner, $actions);
 
-        if ($newPayment->mollie_payment_status === PaymentStatus::STATUS_PAID) {
+        if ($newPayment->mollie_payment_status === PaymentStatus::PAID) {
             $molliePayment->webhookUrl = route('webhooks.mollie.aftercare');
 
             /** @var UpdateMolliePayment $updateMolliePayment */

--- a/src/Refunds/Refund.php
+++ b/src/Refunds/Refund.php
@@ -58,7 +58,7 @@ class Refund extends Model
      */
     public function scopeWhereUnprocessed(Builder $query)
     {
-        return $query->where('mollie_refund_status', RefundStatus::STATUS_PENDING);
+        return $query->where('mollie_refund_status', RefundStatus::PENDING);
     }
 
     public function items(): HasMany
@@ -85,7 +85,7 @@ class Refund extends Model
             $order = Cashier::$orderModel::createProcessedFromItems($orderItems);
 
             $this->order_id = $order->id;
-            $this->mollie_refund_status = RefundStatus::STATUS_REFUNDED;
+            $this->mollie_refund_status = RefundStatus::REFUNDED;
 
             $this->save();
 
@@ -111,7 +111,7 @@ class Refund extends Model
         $refundItems = $this->items;
 
         DB::transaction(function () use ($refundItems) {
-            $this->mollie_refund_status = RefundStatus::STATUS_FAILED;
+            $this->mollie_refund_status = RefundStatus::FAILED;
 
             $this->save();
 

--- a/src/Refunds/RefundBuilder.php
+++ b/src/Refunds/RefundBuilder.php
@@ -79,7 +79,7 @@ class RefundBuilder
     protected static function guardOrderIsPaid(Order $order)
     {
         throw_unless(
-            $order->mollie_payment_status === PaymentStatus::STATUS_PAID,
+            $order->mollie_payment_status === PaymentStatus::PAID,
             new LogicException('Only paid orders can be refunded')
         );
     }

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -16,10 +16,11 @@ use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use PHPUnit\Framework\Attributes\Test;
 
 class BillableTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function testTaxPercentage()
     {
         $user = User::factory()->create([
@@ -29,7 +30,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals(21.5, $user->taxPercentage());
     }
 
-    /** @test */
+    #[Test]
     public function returnsFirstPaymentSubscriptionBuilderIfMandateIdOnOwnerIsNull()
     {
         $this->withConfiguredPlans();
@@ -40,7 +41,7 @@ class BillableTest extends BaseTestCase
         $this->assertInstanceOf(FirstPaymentSubscriptionBuilder::class, $builder);
     }
 
-    /** @test */
+    #[Test]
     public function returnsFirstPaymentSubscriptionBuilderIfOwnerMandateIsInvalid()
     {
         $this->withConfiguredPlans();
@@ -57,7 +58,7 @@ class BillableTest extends BaseTestCase
         $this->assertInstanceOf(FirstPaymentSubscriptionBuilder::class, $builder);
     }
 
-    /** @test */
+    #[Test]
     public function throwExceptionIfMandateIsInPendingState()
     {
         $this->expectException(MandateIsNotYetFinalizedException::class);
@@ -70,7 +71,7 @@ class BillableTest extends BaseTestCase
         $user->newSubscriptionForMandateId('mdt_unique_mandate_id', 'main', 'monthly-10-1')->create();
     }
 
-    /** @test */
+    #[Test]
     public function returnsDefaultSubscriptionBuilderIfOwnerHasValidMandateId()
     {
         $this->withConfiguredPlans();
@@ -86,7 +87,7 @@ class BillableTest extends BaseTestCase
         $this->assertInstanceOf(MandatedSubscriptionBuilder::class, $builder);
     }
 
-    /** @test */
+    #[Test]
     public function canRetrieveRedeemedCoupons()
     {
         $user = User::factory()->create();
@@ -96,7 +97,7 @@ class BillableTest extends BaseTestCase
         $this->assertCount(0, $redeemedCoupons);
     }
 
-    /** @test */
+    #[Test]
     public function canRedeemCouponForExistingSubscription()
     {
         $this->withConfiguredPlans();
@@ -119,7 +120,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals(0, $subscription->appliedCoupons()->count());
     }
 
-    /** @test */
+    #[Test]
     public function canRedeemCouponAndRevokeOtherCoupons()
     {
         $this->withConfiguredPlans();
@@ -145,7 +146,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals(0, $subscription->appliedCoupons()->count());
     }
 
-    /** @test */
+    #[Test]
     public function clearMollieMandate()
     {
         Event::fake();
@@ -163,7 +164,7 @@ class BillableTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function canFindInvoice()
     {
         $user = $this->getUser();
@@ -178,7 +179,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals('find_invoice_test_1', $invoice->id());
     }
 
-    /** @test */
+    #[Test]
     public function findInvoiceReturnsNullIfInvoiceDoesNotExist()
     {
         $user = $this->getUser();
@@ -188,7 +189,7 @@ class BillableTest extends BaseTestCase
         $this->assertNull($invoice);
     }
 
-    /** @test */
+    #[Test]
     public function findInvoiceThrowsExceptionIfInvoiceExistButIsAssociatedWithOtherBillableModel()
     {
         $userA = $this->getUser();
@@ -204,7 +205,7 @@ class BillableTest extends BaseTestCase
         $userB->findInvoice('foo-bar');
     }
 
-    /** @test */
+    #[Test]
     public function canFindInvoiceUsingFindInvoiceOrFail()
     {
         $user = $this->getUser();
@@ -219,7 +220,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals('find_invoice_test_1', $invoice->id());
     }
 
-    /** @test */
+    #[Test]
     public function findInvoiceOrFailThrowsExceptionWhenNotFindingTheInvoice()
     {
         $user = $this->getUser();
@@ -229,7 +230,7 @@ class BillableTest extends BaseTestCase
         $user->findInvoiceOrFail('does_not_exist');
     }
 
-    /** @test */
+    #[Test]
     public function findInvoiceOrFailThrowsExceptionIfInvoiceExistButIsAssociatedWithOtherBillableModel()
     {
         $userA = $this->getUser();
@@ -245,7 +246,7 @@ class BillableTest extends BaseTestCase
         $userB->findInvoiceOrFail('foo-bar');
     }
 
-    /** @test */
+    #[Test]
     public function canFindInvoiceByOrderId()
     {
         $user = $this->getUser();
@@ -267,7 +268,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals('2018-0000-0002', $invoice->id());
     }
 
-    /** @test */
+    #[Test]
     public function canFindInvoiceByOrderIdUsingFindInvoiceByOrderIdOrFail()
     {
         $user = $this->getUser();
@@ -289,7 +290,7 @@ class BillableTest extends BaseTestCase
         $this->assertEquals('2018-0000-0002', $invoice->id());
     }
 
-    /** @test */
+    #[Test]
     public function testHasActiveSubscription()
     {
         $this->withConfiguredPlans();
@@ -306,7 +307,7 @@ class BillableTest extends BaseTestCase
         $this->assertTrue($user->hasActiveSubscription());
     }
 
-    /** @test */
+    #[Test]
     public function testHasActiveSubscriptionsFalse()
     {
         $user = User::factory()->create();

--- a/tests/CashierServiceProviderTest.php
+++ b/tests/CashierServiceProviderTest.php
@@ -4,10 +4,11 @@ namespace Laravel\Cashier\Tests;
 
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\CashierServiceProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 class CashierServiceProviderTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canOptionallySetCurrencyInConfig()
     {
         $this->assertEquals('INEXISTENT', config('cashier.currency', 'INEXISTENT'));
@@ -22,7 +23,7 @@ class CashierServiceProviderTest extends BaseTestCase
         $this->assertEquals('$', Cashier::usesCurrencySymbol());
     }
 
-    /** @test */
+    #[Test]
     public function canOptionallySetCurrencyLocaleInConfig()
     {
         $this->assertEquals('INEXISTENT', config('cashier.currency_locale', 'INEXISTENT'));

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -27,6 +27,7 @@ use Laravel\Cashier\Tests\Fixtures\Subscription as FixtureSubscription;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class CashierTest extends BaseTestCase
 {
@@ -50,7 +51,7 @@ class CashierTest extends BaseTestCase
         Cashier::useCurrency('eur');
     }
 
-    /** @test */
+    #[Test]
     public function cashierUsesPredefinedModels()
     {
         $this->assertEquals(Cashier::$subscriptionModel, CashierSubscription::class);
@@ -64,7 +65,7 @@ class CashierTest extends BaseTestCase
         $this->assertEquals(Cashier::$refundItemModel, CashierRefundItem::class);
     }
 
-    /** @test */
+    #[Test]
     public function cashierUsesConfiguredModels()
     {
         Cashier::useSubscriptionModel(FixtureSubscription::class);
@@ -88,7 +89,7 @@ class CashierTest extends BaseTestCase
         $this->assertEquals(Cashier::$refundItemModel, FixtureRefundItem::class);
     }
 
-    /** @test */
+    #[Test]
     public function testRunningCashierProcessesOpenOrderItems()
     {
         $this->withMockedGetMollieCustomer(2);
@@ -115,7 +116,7 @@ class CashierTest extends BaseTestCase
         $this->assertOrderItemCounts($user, 2, 0);
     }
 
-    /** @test */
+    #[Test]
     public function testRunningCashierProcessesUnprocessedOrderItemsAndSchedulesNext()
     {
         $this->withMockedGetMollieCustomer(2, [
@@ -191,7 +192,7 @@ class CashierTest extends BaseTestCase
         $this->assertOrderItemCounts($user2, 1, 1); // processed 1, scheduled 1
     }
 
-    /** @test */
+    #[Test]
     public function canSwapSubscriptionPlan()
     {
         $this->withTestNow('2019-01-01');
@@ -253,7 +254,7 @@ class CashierTest extends BaseTestCase
         $this->assertOrderItemCounts($user, 4, 1);
     }
 
-    /** @test */
+    #[Test]
     public function canSwapSubscriptionPlanAndReimburseUnusedTime()
     {
         $this->withTestNow('2019-01-01');
@@ -293,7 +294,7 @@ class CashierTest extends BaseTestCase
         $this->assertEquals(1000, $user->orders()->latest()->first()->total);
     }
 
-    /** @test */
+    #[Test]
     public function testFormatAmount()
     {
         $this->assertEquals('1.000,00 €', Cashier::formatAmount(new Money(100000, new Currency('EUR'))));
@@ -324,7 +325,7 @@ class CashierTest extends BaseTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function canOverrideDefaultCurrencySymbol()
     {
         $this->assertEquals('€', Cashier::usesCurrencySymbol());
@@ -336,7 +337,7 @@ class CashierTest extends BaseTestCase
         $this->assertEquals('$', Cashier::usesCurrencySymbol());
     }
 
-    /** @test */
+    #[Test]
     public function canOverrideDefaultCurrencyLocale()
     {
         $this->assertEquals('de_DE', Cashier::usesCurrencyLocale());
@@ -346,7 +347,7 @@ class CashierTest extends BaseTestCase
         $this->assertEquals('nl_NL', Cashier::usesCurrencyLocale());
     }
 
-    /** @test */
+    #[Test]
     public function canOverrideFirstPaymentWebhookUrl()
     {
         $this->assertEquals('mandate-webhook', Cashier::firstPaymentWebhookUrl());
@@ -360,7 +361,7 @@ class CashierTest extends BaseTestCase
         $this->assertEquals('webhook/cashier', Cashier::firstPaymentWebhookUrl());
     }
 
-    /** @test */
+    #[Test]
     public function canOverrideWebhookUrl()
     {
         $this->assertEquals('webhook', Cashier::webhookUrl());

--- a/tests/Charge/FirstPaymentChargeBuilderTest.php
+++ b/tests/Charge/FirstPaymentChargeBuilderTest.php
@@ -7,6 +7,7 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class FirstPaymentChargeBuilderTest extends BaseTestCase
 {
@@ -17,7 +18,7 @@ class FirstPaymentChargeBuilderTest extends BaseTestCase
         $this->withMockedCreateMollieCustomer();
     }
 
-    /** @test */
+    #[Test]
     public function redirectToCheckoutResponse()
     {
         $this->withMockedCreateMolliePayment(1, '3.00');

--- a/tests/Charge/ManageChargesTest.php
+++ b/tests/Charge/ManageChargesTest.php
@@ -6,10 +6,11 @@ use Laravel\Cashier\Charge\FirstPaymentChargeBuilder;
 use Laravel\Cashier\Charge\MandatedChargeBuilder;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
+use PHPUnit\Framework\Attributes\Test;
 
 class ManageChargesTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function usingMandatedChargeBuilderWhenValidMandate()
     {
         $owner = User::factory()->create();
@@ -17,7 +18,7 @@ class ManageChargesTest extends BaseTestCase
         $this->assertInstanceOf(FirstPaymentChargeBuilder::class, $owner->newCharge());
     }
 
-    /** @test */
+    #[Test]
     public function useNewMandatedCharge()
     {
         $this->withMockedGetMollieCustomer(2);

--- a/tests/Console/SyncSubscriptionPlansTest.php
+++ b/tests/Console/SyncSubscriptionPlansTest.php
@@ -9,10 +9,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class SyncSubscriptionPlansTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function it_updates_unprocessed_subscription_order_items_with_current_plan_values()
     {
         // Create an owner and subscription
@@ -58,7 +59,7 @@ class SyncSubscriptionPlansTest extends BaseTestCase
         $this->assertEquals($newDescription, $orderItem->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_processed_subscription_order_items()
     {
         // Create an owner and subscription with a processed order item
@@ -105,7 +106,7 @@ class SyncSubscriptionPlansTest extends BaseTestCase
         $this->assertEquals($oldDescription, $orderItem->description);
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_non_subscription_order_items()
     {
         // Create a generic order item

--- a/tests/Coupon/ConfigCouponRepositoryTest.php
+++ b/tests/Coupon/ConfigCouponRepositoryTest.php
@@ -7,6 +7,7 @@ use Laravel\Cashier\Coupon\Contracts\CouponRepository;
 use Laravel\Cashier\Coupon\Coupon;
 use Laravel\Cashier\Exceptions\CouponNotFoundException;
 use Laravel\Cashier\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConfigCouponRepositoryTest extends BaseTestCase
 {
@@ -39,39 +40,39 @@ class ConfigCouponRepositoryTest extends BaseTestCase
         $this->repository = new ConfigCouponRepository($defaults, $coupons);
     }
 
-    /** @test */
+    #[Test]
     public function ItIsContainerBound()
     {
         $repository = app()->make(CouponRepository::class);
         $this->assertInstanceOf(ConfigCouponRepository::class, $repository);
     }
 
-    /** @test */
+    #[Test]
     public function findReturnsNullWhenNotFound()
     {
         $this->assertNull($this->repository->find('some_wrong_name'));
     }
 
-    /** @test */
+    #[Test]
     public function findReturnsCouponWhenFound()
     {
         $this->assertInstanceOf(Coupon::class, $this->repository->find('test-coupon'));
     }
 
-    /** @test */
+    #[Test]
     public function findOrFailCorrect()
     {
         $this->assertInstanceOf(Coupon::class, $this->repository->findOrFail('test-coupon'));
     }
 
-    /** @test */
+    #[Test]
     public function findOrFailWrong()
     {
         $this->expectException(CouponNotFoundException::class);
         $this->repository->findOrFail('some_wrong_name');
     }
 
-    /** @test */
+    #[Test]
     public function findOrFailIsCaseInsensitive()
     {
         $lowercaseCoupon = $this->repository->find('test-coupon');
@@ -81,7 +82,7 @@ class ConfigCouponRepositoryTest extends BaseTestCase
         $this->assertEquals($lowercaseCoupon, $uppercaseCoupon);
     }
 
-    /** @test */
+    #[Test]
     public function itHandlesTimesAttribute()
     {
         $coupon = $this->repository->findOrFail('test-coupon');

--- a/tests/Coupon/CouponOrderItemPreprocessorTest.php
+++ b/tests/Coupon/CouponOrderItemPreprocessorTest.php
@@ -10,10 +10,11 @@ use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class CouponOrderItemPreprocessorTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function appliesCoupon()
     {
         $this->withMockedCouponRepository();
@@ -38,7 +39,7 @@ class CouponOrderItemPreprocessorTest extends BaseTestCase
         $this->assertEquals(0, $redeemedCoupon->refresh()->times_left);
     }
 
-    /** @test */
+    #[Test]
     public function passesThroughWhenNoRedeemedCoupon()
     {
         $preprocessor = new CouponOrderItemPreprocessor();

--- a/tests/Coupon/MultiCurrencyCouponOrderItemPreprocessorTest.php
+++ b/tests/Coupon/MultiCurrencyCouponOrderItemPreprocessorTest.php
@@ -11,10 +11,11 @@ use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class MultiCurrencyCouponOrderItemPreprocessorTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function appliesCoupon()
     {
         $this->withMockedUsdCouponRepository();

--- a/tests/Coupon/PercentageCouponTest.php
+++ b/tests/Coupon/PercentageCouponTest.php
@@ -11,10 +11,11 @@ use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class PercentageCouponTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function couponCalculatesTheRightPrice()
     {
         $couponHandler = new PercentageDiscountHandler;
@@ -50,7 +51,7 @@ class PercentageCouponTest extends BaseTestCase
         $this->assertEquals(-2430, $result[1]->unit_price);
     }
 
-    /** @test */
+    #[Test]
     public function percentageCouponWithNoTaxCalculatesDiscountFromSubtotalNotTotal()
     {
         // 50% coupon on €150 item with 21% VAT
@@ -124,7 +125,7 @@ class PercentageCouponTest extends BaseTestCase
         $this->assertEquals(10650, $finalTotal);
     }
 
-    /** @test */
+    #[Test]
     public function percentageCouponWithTaxCalculatesDiscountFromSubtotalNotTotal()
     {
         // 50% coupon on €150 item with 21% VAT, no_tax = false

--- a/tests/Coupon/RedeemedCouponTest.php
+++ b/tests/Coupon/RedeemedCouponTest.php
@@ -6,10 +6,11 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Coupon\RedeemedCoupon;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\RedeemedCouponFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class RedeemedCouponTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canBeRevoked()
     {
         /** @var RedeemedCoupon $redeemedCoupon */

--- a/tests/Credit/CreditTest.php
+++ b/tests/Credit/CreditTest.php
@@ -6,10 +6,11 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class CreditTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function testAddAmountForOwner()
     {
         $user = User::factory()->create();
@@ -29,7 +30,7 @@ class CreditTest extends BaseTestCase
         $this->assertTrue(Money::USD(12348)->equals($creditUSD->money()));
     }
 
-    /** @test */
+    #[Test]
     public function testMaxOutForOwner()
     {
         $user = User::factory()->create();

--- a/tests/Database/Factories/RefundFactory.php
+++ b/tests/Database/Factories/RefundFactory.php
@@ -31,7 +31,7 @@ class RefundFactory extends Factory
             'owner_type' => User::class,
             'original_order_id' => 1,
             'mollie_refund_id' => 're_dummy_refund_id',
-            'mollie_refund_status' => RefundStatus::STATUS_PENDING,
+            'mollie_refund_status' => RefundStatus::PENDING,
         ];
     }
 }

--- a/tests/EventServiceProviderTest.php
+++ b/tests/EventServiceProviderTest.php
@@ -7,10 +7,11 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\OrderInvoiceAvailable;
 use Laravel\Cashier\Events\OrderPaymentPaid;
 use Laravel\Cashier\Tests\Database\Factories\OrderFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class EventServiceProviderTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function itIsWiredUpAndFiring()
     {
         Event::fake(OrderInvoiceAvailable::class);

--- a/tests/FirstPayment/Actions/AddBalanceTest.php
+++ b/tests/FirstPayment/Actions/AddBalanceTest.php
@@ -9,10 +9,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class AddBalanceTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canGetPayload()
     {
         $action = new AddBalance(
@@ -36,7 +37,7 @@ class AddBalanceTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayload()
     {
         $action = AddBalance::createFromPayload([
@@ -56,7 +57,7 @@ class AddBalanceTest extends BaseTestCase
         $this->assertEquals(0, $action->getTaxPercentage());
     }
 
-    /** @test */
+    #[Test]
     public function canExecute()
     {
         $user = User::factory()->create();

--- a/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
+++ b/tests/FirstPayment/Actions/AddGenericOrderItemTest.php
@@ -9,10 +9,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class AddGenericOrderItemTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canGetPayload()
     {
         $action = new AddGenericOrderItem(
@@ -36,7 +37,7 @@ class AddGenericOrderItemTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayload()
     {
         $action = AddGenericOrderItem::createFromPayload([
@@ -55,7 +56,7 @@ class AddGenericOrderItemTest extends BaseTestCase
         $this->assertEquals(20, $action->getTaxPercentage());
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithoutTaxPercentage()
     {
         $action = AddGenericOrderItem::createFromPayload([
@@ -73,7 +74,7 @@ class AddGenericOrderItemTest extends BaseTestCase
         $this->assertEquals(0, $action->getTaxPercentage());
     }
 
-    /** @test */
+    #[Test]
     public function canExecute()
     {
         $user = User::factory()->create(['tax_percentage' => 20]);

--- a/tests/FirstPayment/Actions/ApplySubscriptionCouponToPaymentTest.php
+++ b/tests/FirstPayment/Actions/ApplySubscriptionCouponToPaymentTest.php
@@ -9,6 +9,7 @@ use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
+use PHPUnit\Framework\Attributes\Test;
 
 class ApplySubscriptionCouponToPaymentTest extends BaseTestCase
 {
@@ -35,32 +36,32 @@ class ApplySubscriptionCouponToPaymentTest extends BaseTestCase
         $this->action = new Action($this->owner, $this->coupon, $orderItems);
     }
 
-    /** @test */
+    #[Test]
     public function testGetTotalReturnsDiscountSubtotal()
     {
         $this->assertMoneyEURCents(-500, $this->action->getTotal());
     }
 
-    /** @test */
+    #[Test]
     public function testTaxDefaultsToZero()
     {
         $this->assertEquals(0, $this->action->getTaxPercentage());
         $this->assertMoneyEURCents(0, $this->action->getTax());
     }
 
-    /** @test */
+    #[Test]
     public function testCreateFromPayloadReturnsNull()
     {
         $this->assertNull(Action::createFromPayload(['foo' => 'bar'], User::factory()->make()));
     }
 
-    /** @test */
+    #[Test]
     public function testGetPayloadReturnsNull()
     {
         $this->assertNull($this->action->getPayload());
     }
 
-    /** @test */
+    #[Test]
     public function testExecuteReturnsEmptyOrderItemCollection()
     {
         $result = $this->action->execute();

--- a/tests/FirstPayment/Actions/StartSubscriptionTest.php
+++ b/tests/FirstPayment/Actions/StartSubscriptionTest.php
@@ -7,6 +7,7 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\FirstPayment\Actions\StartSubscription;
 use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class StartSubscriptionTest extends BaseTestCase
 {
@@ -18,8 +19,7 @@ class StartSubscriptionTest extends BaseTestCase
             ->withTestNow('2019-01-01');
     }
 
-    /** @test
-     */
+    #[Test]
     public function canGetBasicPayload()
     {
         $action = new StartSubscription(
@@ -44,7 +44,7 @@ class StartSubscriptionTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canGetPayloadWithTrialDays()
     {
         $action = new StartSubscription(
@@ -72,7 +72,7 @@ class StartSubscriptionTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canGetPayloadWithTrialUntil()
     {
         $action = new StartSubscription(
@@ -100,7 +100,7 @@ class StartSubscriptionTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canGetPayloadWithSkipTrial()
     {
         $action = new StartSubscription(
@@ -128,7 +128,7 @@ class StartSubscriptionTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canGetPayloadWithCoupon()
     {
         $this->withMockedCouponRepository();
@@ -158,13 +158,13 @@ class StartSubscriptionTest extends BaseTestCase
         ], $payload);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromBasicPayload()
     {
         $this->assertFromPayloadToPayload();
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithTrialUntil()
     {
         $this->assertFromPayloadToPayload([
@@ -176,7 +176,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithTrialDays()
     {
         $this->assertFromPayloadToPayload([
@@ -188,7 +188,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithSkipTrial()
     {
         $this->assertFromPayloadToPayload([
@@ -200,7 +200,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithQuantity()
     {
         $this->assertFromPayloadToPayload([
@@ -212,7 +212,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithTrialAndQuantity()
     {
         $this->assertFromPayloadToPayload([
@@ -225,7 +225,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithCouponNoTrial()
     {
         $this->withMockedCouponRepository();
@@ -238,7 +238,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithCouponAndTrial()
     {
         $this->withMockedCouponRepository();
@@ -252,7 +252,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromPayloadWithoutTaxPercentage()
     {
         $this->withMockedCouponRepository();
@@ -267,7 +267,7 @@ class StartSubscriptionTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function canStartDefaultSubscription()
     {
         Carbon::setTestNow('2019-01-29');
@@ -311,7 +311,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(1000, $scheduledItem->total);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithTrialDays()
     {
         $user = $this->getMandatedUser(true, ['tax_percentage' => 20]);
@@ -361,7 +361,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(20, $scheduledItem->tax_percentage);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithTrialUntil()
     {
         $this->withMockedGetMollieCustomer(2);
@@ -408,7 +408,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(1000, $scheduledItem->total);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithQuantityNoTrial()
     {
         $this->withMockedGetMollieCustomer(2);
@@ -456,7 +456,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(5 * 1000, $scheduledItem->total);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithQuantityAndTrialUntil()
     {
         $this->withMockedGetMollieCustomer(2);
@@ -506,7 +506,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(5 * 1000, $scheduledItem->total);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionUsingNextPaymentAt()
     {
         $this->withMockedGetMollieCustomer(2);
@@ -545,7 +545,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertCarbon(now()->addWeeks(2), $scheduledItem->process_at);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithCouponNoTrial()
     {
         $this->withMockedCouponRepository();
@@ -598,7 +598,7 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(-500, $couponItem->total);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithCouponAndTrial()
     {
         $this->withMockedCouponRepository();

--- a/tests/FirstPayment/Actions/StartSubscriptionWithPlanIntervalArrayTest.php
+++ b/tests/FirstPayment/Actions/StartSubscriptionWithPlanIntervalArrayTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\Tests\FirstPayment\Actions;
 use Carbon\Carbon;
 use Laravel\Cashier\FirstPayment\Actions\StartSubscription;
 use Laravel\Cashier\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class StartSubscriptionWithPlanIntervalArrayTest extends BaseTestCase
 {
@@ -16,7 +17,7 @@ class StartSubscriptionWithPlanIntervalArrayTest extends BaseTestCase
             ->withTestNow('2019-01-29');
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithFixedIntervalTest()
     {
         $this->withMockedGetMollieCustomer(2);
@@ -43,7 +44,7 @@ class StartSubscriptionWithPlanIntervalArrayTest extends BaseTestCase
         $this->assertCarbon(Carbon::parse('2019-02-28'), $subscription->cycle_ends_at);
     }
 
-    /** @test */
+    #[Test]
     public function canStartSubscriptionWithoutFixedInterval()
     {
         $this->withMockedGetMollieCustomer(2);

--- a/tests/FirstPayment/FirstPaymentBuilderTest.php
+++ b/tests/FirstPayment/FirstPaymentBuilderTest.php
@@ -12,6 +12,7 @@ use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Types\SequenceType;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class FirstPaymentBuilderTest extends BaseTestCase
 {
@@ -22,7 +23,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $this->withMockedCreateMollieCustomer();
     }
 
-    /** @test */
+    #[Test]
     public function canBuildPayload()
     {
         $owner = User::factory()->create();
@@ -53,7 +54,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $customerId = $payload['customerId'];
         unset($payload['customerId']);
         $check_payload = [
-            'sequenceType' => SequenceType::SEQUENCETYPE_FIRST,
+            'sequenceType' => SequenceType::FIRST,
             'description' => 'Test mandate payment',
             'amount' => [
                 'value' => '10.00',
@@ -75,7 +76,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $this->assertEquals(0, $owner->orders()->count());
     }
 
-    /** @test */
+    #[Test]
     public function createsMolliePayment()
     {
         $owner = User::factory()->create();
@@ -112,7 +113,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $this->assertInstanceOf(MolliePayment::class, $payment);
     }
 
-    /** @test */
+    #[Test]
     public function parsesRedirectUrlPaymentIdUponPaymentCreation()
     {
         $owner = User::factory()->create();
@@ -131,7 +132,7 @@ class FirstPaymentBuilderTest extends BaseTestCase
         $this->assertEquals('https://www.example.com/tr_unique_id', $payment->redirectUrl);
     }
 
-    /** @test */
+    #[Test]
     public function storesLocalPaymentRecord()
     {
         $owner = User::factory()->create();

--- a/tests/FirstPayment/FirstPaymentHandlerTest.php
+++ b/tests/FirstPayment/FirstPaymentHandlerTest.php
@@ -12,10 +12,11 @@ use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Types\PaymentStatus;
+use PHPUnit\Framework\Attributes\Test;
 
 class FirstPaymentHandlerTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function handlesMolliePayments()
     {
         Event::fake();
@@ -92,7 +93,7 @@ class FirstPaymentHandlerTest extends BaseTestCase
         $payment->customerId = 'cst_unique_customer_id';
         $payment->mandateId = 'mdt_unique_mandate_id';
         $payment->amount = (object) ['value' => '10.00', 'currency' => 'EUR'];
-        $payment->status = PaymentStatus::STATUS_PAID;
+        $payment->status = PaymentStatus::PAID;
         $payment->metadata = json_decode(json_encode([
             'owner' => [
                 'type' => User::class,

--- a/tests/Helpers/HelpersTest.php
+++ b/tests/Helpers/HelpersTest.php
@@ -5,10 +5,11 @@ namespace Laravel\Cashier\Tests\Helpers;
 use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class HelpersTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function testMoney()
     {
         $money = money(1234, 'EUR');
@@ -17,14 +18,14 @@ class HelpersTest extends TestCase
         $this->assertTrue(Money::EUR(1234)->equals($money));
     }
 
-    /** @test */
+    #[Test]
     public function testDecimalToMoney()
     {
         $money = decimal_to_money('12.34', 'EUR');
         $this->assertTrue(Money::EUR(1234)->equals($money));
     }
 
-    /** @test */
+    #[Test]
     public function testMoneyToMollieArray()
     {
         $moneyEUR = Money::EUR(1234);
@@ -44,7 +45,7 @@ class HelpersTest extends TestCase
         ], $arrayUSD);
     }
 
-    /** @test */
+    #[Test]
     public function testMollieArrayToMoney()
     {
         $arrayEUR = [
@@ -64,7 +65,7 @@ class HelpersTest extends TestCase
         $this->assertTrue(Money::USD(9876)->equals($moneyUSD));
     }
 
-    /** @test */
+    #[Test]
     public function testMollieObjectToMoney()
     {
         $objectEUR = (object) [

--- a/tests/Http/Controllers/AftercareWebhookControllerTest.php
+++ b/tests/Http/Controllers/AftercareWebhookControllerTest.php
@@ -18,12 +18,14 @@ use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Resources\Refund as MollieRefund;
+use Mollie\Api\Resources\RefundCollection;
 use Mollie\Api\Types\PaymentStatus as MolliePaymentStatus;
 use Mollie\Api\Types\RefundStatus as MollieRefundStatus;
+use PHPUnit\Framework\Attributes\Test;
 
 class AftercareWebhookControllerTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function itDetectsNewChargebacks()
     {
         Event::fake();
@@ -64,7 +66,7 @@ class AftercareWebhookControllerTest extends BaseTestCase
         Event::assertDispatched(ChargebackReceived::class);
     }
 
-    /** @test */
+    #[Test]
     public function itDetectsNewRefunds()
     {
         Event::fake();
@@ -94,7 +96,7 @@ class AftercareWebhookControllerTest extends BaseTestCase
             'owner_id' => $user->id,
             'owner_type' => get_class($user),
             'mollie_refund_id' => $mollieRefundId,
-            'mollie_refund_status' => MollieRefundStatus::STATUS_PENDING,
+            'mollie_refund_status' => MollieRefundStatus::PENDING,
             'total' => 1000,
             'currency' => 'EUR',
         ]);
@@ -107,7 +109,7 @@ class AftercareWebhookControllerTest extends BaseTestCase
 
         $mollieRefund = new MollieRefund(new MollieApiClient);
         $mollieRefund->id = $mollieRefundId;
-        $mollieRefund->status = MollieRefundStatus::STATUS_REFUNDED;
+        $mollieRefund->status = MollieRefundStatus::REFUNDED;
 
         $molliePayment = $this->getMockBuilder(MolliePayment::class)
             ->setConstructorArgs([new MollieApiClient])
@@ -116,10 +118,13 @@ class AftercareWebhookControllerTest extends BaseTestCase
 
         $molliePayment
             ->method('refunds')
-            ->willReturn([$mollieRefund]);
+            ->willReturn(new RefundCollection(
+                $this->createMock(\Mollie\Api\Contracts\Connector::class),
+                [$mollieRefund],
+            ));
 
         $molliePayment->id = $molliePaymentId;
-        $molliePayment->status = MolliePaymentStatus::STATUS_PAID;
+        $molliePayment->status = MolliePaymentStatus::PAID;
         $molliePayment->amount = (object) [
             'currency' => 'EUR',
             'value' => '10.00',

--- a/tests/Http/Controllers/WebhookControllerTest.php
+++ b/tests/Http/Controllers/WebhookControllerTest.php
@@ -20,10 +20,11 @@ use Laravel\Cashier\Types\SubscriptionCancellationReason;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
+use PHPUnit\Framework\Attributes\Test;
 
 class WebhookControllerTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function retrievesPaymentResource()
     {
         $payment = new MolliePayment(resolve(MollieApiClient::class));
@@ -34,7 +35,7 @@ class WebhookControllerTest extends BaseTestCase
         $this->assertInstanceOf(MolliePayment::class, $this->getController()->getMolliePaymentById($payment->id));
     }
 
-    /** @test **/
+    #[Test]
     public function MollieApiExceptionIsCatchedWhenDebugDisabled()
     {
         $wrongId = 'sub_xxxxxxxxxxx';
@@ -44,7 +45,7 @@ class WebhookControllerTest extends BaseTestCase
         $this->assertNull($this->getController()->getMolliePaymentById($wrongId));
     }
 
-    /** @test **/
+    #[Test]
     public function MollieApiExceptionIsThrownWhenDebugEnabled()
     {
         $wrongId = 'sub_xxxxxxxxxxx';
@@ -56,7 +57,7 @@ class WebhookControllerTest extends BaseTestCase
         $this->assertNull($this->getController()->getMolliePaymentById($wrongId));
     }
 
-    /** @test **/
+    #[Test]
     public function handlesUnexistingIdGracefully()
     {
         $wrongId = 'sub_xxxxxxxxxxx';
@@ -68,7 +69,7 @@ class WebhookControllerTest extends BaseTestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /** @test **/
+    #[Test]
     public function handlesPaymentFailed()
     {
         $this->withConfiguredPlans();
@@ -140,7 +141,7 @@ class WebhookControllerTest extends BaseTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function handlesPaymentPaid()
     {
         $this->withConfiguredPlans();
@@ -191,7 +192,7 @@ class WebhookControllerTest extends BaseTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function skipsIfPaymentStatusUnchanged()
     {
         Event::fake();

--- a/tests/ManageSubscriptionTest.php
+++ b/tests/ManageSubscriptionTest.php
@@ -21,9 +21,6 @@ class ManageSubscriptionTest extends BaseTestCase
 
     /**
      * Assert that a new subscription and its order items can be created and processed.
-     *
-
-
      */
     #[Test]
     public function canCreateDirectDebitSubscriptionForMandatedCustomer()

--- a/tests/ManageSubscriptionTest.php
+++ b/tests/ManageSubscriptionTest.php
@@ -9,6 +9,7 @@ use Laravel\Cashier\Events\SubscriptionQuantityUpdated;
 use Laravel\Cashier\Events\SubscriptionResumed;
 use Laravel\Cashier\Events\SubscriptionStarted;
 use Laravel\Cashier\Tests\Fixtures\User;
+use PHPUnit\Framework\Attributes\Test;
 
 class ManageSubscriptionTest extends BaseTestCase
 {
@@ -21,8 +22,10 @@ class ManageSubscriptionTest extends BaseTestCase
     /**
      * Assert that a new subscription and its order items can be created and processed.
      *
-     * @test
+
+
      */
+    #[Test]
     public function canCreateDirectDebitSubscriptionForMandatedCustomer()
     {
         $this->withMockedGetMollieCustomer(10);

--- a/tests/Mollie/CreateMollieCustomerTest.php
+++ b/tests/Mollie/CreateMollieCustomerTest.php
@@ -6,15 +6,15 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMollieCustomer;
 use Mollie\Api\Resources\Customer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class CreateMollieCustomerTest extends BaseMollieInteraction
 {
     protected $interactWithMollieAPI = true;
 
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var CreateMollieCustomer $action */

--- a/tests/Mollie/CreateMolliePaymentTest.php
+++ b/tests/Mollie/CreateMolliePaymentTest.php
@@ -6,13 +6,13 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMolliePayment;
 use Mollie\Api\Resources\Payment;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class CreateMolliePaymentTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var CreateMolliePayment $action */

--- a/tests/Mollie/CreateMollieRefundTest.php
+++ b/tests/Mollie/CreateMollieRefundTest.php
@@ -6,14 +6,14 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\CreateMollieRefund;
 use Mollie\Api\Resources\Refund;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class CreateMollieRefundTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     * @group requires_manual_intervention
-     */
+    #[Test]
+    #[Group('mollie_integration')]
+    #[Group('requires_manual_intervention')]
     public function testExecute()
     {
         // Manually create a new refundable payment first before running this.

--- a/tests/Mollie/GetMollieCustomerTest.php
+++ b/tests/Mollie/GetMollieCustomerTest.php
@@ -6,13 +6,13 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMollieCustomer;
 use Mollie\Api\Resources\Customer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class GetMollieCustomerTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var GetMollieCustomer $action */

--- a/tests/Mollie/GetMollieMandateTest.php
+++ b/tests/Mollie/GetMollieMandateTest.php
@@ -6,13 +6,13 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMollieMandate;
 use Mollie\Api\Resources\Mandate;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class GetMollieMandateTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var \Laravel\Cashier\Mollie\GetMollieMandate $action */

--- a/tests/Mollie/GetMolliePaymentTest.php
+++ b/tests/Mollie/GetMolliePaymentTest.php
@@ -6,13 +6,13 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMolliePayment;
 use Mollie\Api\Resources\Payment;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class GetMolliePaymentTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var GetMolliePayment $action */

--- a/tests/Mollie/GetMollieRefundTest.php
+++ b/tests/Mollie/GetMollieRefundTest.php
@@ -6,13 +6,13 @@ namespace Laravel\Cashier\Tests\Mollie;
 
 use Laravel\Cashier\Mollie\Contracts\GetMollieRefund;
 use Mollie\Api\Resources\Refund;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class GetMollieRefundTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var GetMollieRefund $action */

--- a/tests/Mollie/UpdateMolliePaymentTest.php
+++ b/tests/Mollie/UpdateMolliePaymentTest.php
@@ -8,13 +8,13 @@ use Illuminate\Support\Str;
 use Laravel\Cashier\Mollie\Contracts\UpdateMolliePayment;
 use Mollie\Api\Resources\Payment;
 use Mollie\Laravel\Facades\Mollie;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class UpdateMolliePaymentTest extends BaseMollieInteraction
 {
-    /**
-     * @test
-     * @group mollie_integration
-     */
+    #[Test]
+    #[Group('mollie_integration')]
     public function testExecute()
     {
         /** @var UpdateMolliePayment $action */

--- a/tests/Order/InvoiceTest.php
+++ b/tests/Order/InvoiceTest.php
@@ -10,10 +10,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class InvoiceTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canAddItemsToInvoice()
     {
         $itemA = OrderItemFactory::new()->make([
@@ -68,7 +69,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertMoneyEURCents(7050, $invoice->rawTotal());
     }
 
-    /** @test */
+    #[Test]
     public function canSetReceiverAddress()
     {
         $invoice = new Invoice('EUR');
@@ -86,7 +87,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('John Doe<br>john@example.com', $invoice->receiverAddress('<br>'));
     }
 
-    /** @test */
+    #[Test]
     public function canSetDate()
     {
         $now = Carbon::parse('Feb 14 2016');
@@ -102,7 +103,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertCarbon($now->addYears(2), $invoice->date());
     }
 
-    /** @test */
+    #[Test]
     public function canReceiveDateInDifferentLanguages()
     {
         $invoice = new Invoice('EUR', null, Carbon::parse('May 15 2023'));
@@ -112,7 +113,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('Mai 15, 2023', $invoice->isoFormattedDate());
     }
 
-    /** @test */
+    #[Test]
     public function canAddExtraInformation()
     {
         $invoice = new Invoice('EUR');
@@ -125,7 +126,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('This is some nice extra information', $invoice->extraInformation(''));
     }
 
-    /** @test */
+    #[Test]
     public function canSetInvoiceId()
     {
         $invoice = new Invoice('EUR', '2018-1234567890');
@@ -135,7 +136,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('2018-0987654321', $invoice->id());
     }
 
-    /** @test */
+    #[Test]
     public function canSetStartingBalance()
     {
         $invoice = new Invoice('EUR');
@@ -149,7 +150,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('15,25 €', $invoice->startingBalance());
     }
 
-    /** @test */
+    #[Test]
     public function canSetCompletedBalance()
     {
         $invoice = new Invoice('EUR');
@@ -161,7 +162,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('15,25 €', $invoice->completedBalance());
     }
 
-    /** @test */
+    #[Test]
     public function canSetUsedBalance()
     {
         $invoice = new Invoice('EUR');
@@ -173,7 +174,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertEquals('15,25 €', $invoice->usedBalance());
     }
 
-    /** @test */
+    #[Test]
     public function canGetAsView()
     {
         $items = OrderItemFactory::new()->times(2)->make();
@@ -192,7 +193,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertTrue($item2->is($items[1]));
     }
 
-    /** @test */
+    #[Test]
     public function canGetAsPdf()
     {
         $items = OrderItemFactory::new()->times(2)->make();
@@ -205,7 +206,7 @@ class InvoiceTest extends BaseTestCase
         $this->assertNotNull($pdf);
     }
 
-    /** @test */
+    #[Test]
     public function canGetAsDownloadResponse()
     {
         Carbon::setTestNow(Carbon::parse('2018-12-31'));

--- a/tests/Order/OrderCollectionTest.php
+++ b/tests/Order/OrderCollectionTest.php
@@ -6,10 +6,11 @@ use Laravel\Cashier\Order\Invoice;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
+use PHPUnit\Framework\Attributes\Test;
 
 class OrderCollectionTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canGetInvoices()
     {
         $user = User::factory()->create();

--- a/tests/Order/OrderInvoiceSubscriberTest.php
+++ b/tests/Order/OrderInvoiceSubscriberTest.php
@@ -11,6 +11,7 @@ use Laravel\Cashier\Order\OrderInvoiceSubscriber;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderFactory;
 use Mollie\Api\Resources\Payment;
+use PHPUnit\Framework\Attributes\Test;
 
 class OrderInvoiceSubscriberTest extends BaseTestCase
 {
@@ -23,7 +24,7 @@ class OrderInvoiceSubscriberTest extends BaseTestCase
         $this->subscriber = new OrderInvoiceSubscriber;
     }
 
-    /** @test */
+    #[Test]
     public function itHandlesTheFirstPaymentPaidEvent()
     {
         $this->assertItHandlesEvent(
@@ -32,7 +33,7 @@ class OrderInvoiceSubscriberTest extends BaseTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function itHandlesTheOrderPaymentPaidEvent()
     {
         $this->assertItHandlesEvent(

--- a/tests/Order/OrderItemCollectionTest.php
+++ b/tests/Order/OrderItemCollectionTest.php
@@ -8,10 +8,11 @@ use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
+use PHPUnit\Framework\Attributes\Test;
 
 class OrderItemCollectionTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function testCurrencies()
     {
         $collection = new OrderItemCollection([
@@ -23,7 +24,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $this->assertEquals(collect(['USD', 'EUR']), $collection->currencies());
     }
 
-    /** @test */
+    #[Test]
     public function testCurrency()
     {
         $collection = new OrderItemCollection([
@@ -34,7 +35,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $this->assertEquals('USD', $collection->currency());
     }
 
-    /** @test */
+    #[Test]
     public function testCurrencyThrowsExceptionWhenMultipleCurrenciesAreUsed()
     {
         $collection = new OrderItemCollection([
@@ -48,7 +49,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $collection->currency();
     }
 
-    /** @test */
+    #[Test]
     public function canGetTotal()
     {
         $collection = new OrderItemCollection([
@@ -67,7 +68,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $this->assertMoneyEURCents(40095, $collection->getTotal());
     }
 
-    /** @test */
+    #[Test]
     public function cannotGetTotalForMultipleCurrencies()
     {
         $collection = new OrderItemCollection([
@@ -80,7 +81,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $collection->getTotal();
     }
 
-    /** @test */
+    #[Test]
     public function testOwners()
     {
         User::factory(3)->create()->each(function ($owner) {
@@ -95,7 +96,7 @@ class OrderItemCollectionTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function testWhereOwners()
     {
         $item1 = OrderItemFactory::new()->make([
@@ -132,7 +133,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $this->assertTrue($owner_2_group->contains($item3));
     }
 
-    /** @test */
+    #[Test]
     public function testWhereCurrency()
     {
         $item1 = OrderItemFactory::new()->EUR()->make();
@@ -155,7 +156,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $this->assertTrue($usd_group->contains($item3));
     }
 
-    /** @test */
+    #[Test]
     public function testChunkByOwner()
     {
         User::factory()->create(['id' => 1]);
@@ -191,7 +192,7 @@ class OrderItemCollectionTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function testChunkByCurrency()
     {
         $collection = new OrderItemCollection([
@@ -208,7 +209,7 @@ class OrderItemCollectionTest extends BaseTestCase
         $this->assertEquals(['EUR', 'USD'], $result->keys()->all());
     }
 
-    /** @test */
+    #[Test]
     public function testChunkByOwnerAndCurrency()
     {
         User::factory()->create(['id' => 1]);
@@ -241,7 +242,7 @@ class OrderItemCollectionTest extends BaseTestCase
         ], $result->keys()->all());
     }
 
-    /** @test */
+    #[Test]
     public function testTaxPercentages()
     {
         $collection = new OrderItemCollection([

--- a/tests/Order/OrderItemPreprocessorCollectionTest.php
+++ b/tests/Order/OrderItemPreprocessorCollectionTest.php
@@ -7,10 +7,11 @@ use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Order\OrderItemPreprocessorCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class OrderItemPreprocessorCollectionTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function handlesOrderItem()
     {
         $fakePreprocessor = $this->getFakePreprocessor(OrderItemFactory::new()->times(2)->make());
@@ -24,7 +25,7 @@ class OrderItemPreprocessorCollectionTest extends BaseTestCase
         $fakePreprocessor->assertOrderItemHandled($item);
     }
 
-    /** @test */
+    #[Test]
     public function invokesPreprocessorsOneByOne()
     {
         $preprocessor1 = $this->getFakePreprocessor(OrderItemFactory::new()->times(1)->make());
@@ -38,7 +39,7 @@ class OrderItemPreprocessorCollectionTest extends BaseTestCase
         $this->assertEquals(2, $result->count());
     }
 
-    /** @test */
+    #[Test]
     public function handlesEmptyPreprocessorCollection()
     {
         $preprocessors = new OrderItemPreprocessorCollection;

--- a/tests/Order/OrderNumberGeneratorTest.php
+++ b/tests/Order/OrderNumberGeneratorTest.php
@@ -8,6 +8,7 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Order\OrderNumberGenerator;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class OrderNumberGeneratorTest extends BaseTestCase
 {
@@ -19,13 +20,13 @@ class OrderNumberGeneratorTest extends BaseTestCase
         $this->generator = new OrderNumberGenerator;
     }
 
-    /** @test */
+    #[Test]
     public function canGenerateANumber()
     {
         $this->assertNotNull($this->generator->generate());
     }
 
-    /** @test */
+    #[Test]
     public function numberStartsWithCurrentYear()
     {
         Carbon::setTestNow(Carbon::parse('1 jul 2018'));
@@ -33,7 +34,7 @@ class OrderNumberGeneratorTest extends BaseTestCase
         $this->assertTrue(Str::startsWith($number = $this->generator->generate(), '2018-'));
     }
 
-    /** @test */
+    #[Test]
     public function usesConfiguredOffsetAndModelCount()
     {
         config(['cashier.order_number_generator.offset' => 15]);
@@ -45,7 +46,7 @@ class OrderNumberGeneratorTest extends BaseTestCase
         $this->assertTrue(Str::endsWith($this->generator->generate(), '19'));
     }
 
-    /** @test */
+    #[Test]
     public function hasAReadableFormat()
     {
         Carbon::setTestNow(Carbon::parse(('1 jul 2018')));

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -23,6 +23,8 @@ use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\Types\PaymentStatus;
 use Money\Currency;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 
 class OrderTest extends BaseTestCase
 {
@@ -33,7 +35,7 @@ class OrderTest extends BaseTestCase
         $this->withConfiguredPlans();
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromOrderItemsAndProcess()
     {
         Carbon::setTestNow(Carbon::parse('2018-01-01'));
@@ -92,7 +94,7 @@ class OrderTest extends BaseTestCase
         $this->assertEquals('open', $order->mollie_payment_status);
     }
 
-    /** @test */
+    #[Test]
     public function creatingANewOrderSchedulesNextOrderItems()
     {
         $user = User::factory()->create(['id' => 2]);
@@ -129,7 +131,7 @@ class OrderTest extends BaseTestCase
         $this->assertSame(0.0, $scheduled_item->tax_percentage);
     }
 
-    /** @test */
+    #[Test]
     public function yieldsOrderCollection()
     {
         $collection = OrderFactory::new()->times(2)->make();
@@ -137,7 +139,7 @@ class OrderTest extends BaseTestCase
         $this->assertInstanceOf(OrderCollection::class, $collection);
     }
 
-    /** @test */
+    #[Test]
     public function handlesOwnerBalance()
     {
         // Owner with 15 euro balance
@@ -204,7 +206,7 @@ class OrderTest extends BaseTestCase
         $this->assertSame(1500, $order->balance_before);
     }
 
-    /** @test */
+    #[Test]
     public function canGetInvoice()
     {
         $user = User::factory()->create(['extra_billing_information' => "Some dummy\nextra billing information"]);
@@ -236,7 +238,7 @@ class OrderTest extends BaseTestCase
         $this->assertMoneyEURCents(29024, $invoice->rawTotalDue());
     }
 
-    /** @test */
+    #[Test]
     public function doesNotProcessPaymentIfTotalDueIsZero()
     {
         Event::fake();
@@ -259,7 +261,7 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
-    /** @test */
+    #[Test]
     public function createsAMolliePaymentIfTotalDueIsLargerThanMolliesMinimum()
     {
         Event::fake();
@@ -293,7 +295,7 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
-    /** @test */
+    #[Test]
     public function createsAMolliePaymentIfMolliesMaximumIsNull()
     {
         Event::fake();
@@ -327,7 +329,7 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
-    /** @test */
+    #[Test]
     public function notCreatesAMolliePaymentIfTotalDueIsGreathenThanMolliesMaximum()
     {
         Event::fake();
@@ -355,7 +357,7 @@ class OrderTest extends BaseTestCase
         $order->processPayment();
     }
 
-    /** @test */
+    #[Test]
     public function handlesAnInvalidMandateWhenProcessingThePayment()
     {
         Event::fake();
@@ -388,7 +390,7 @@ class OrderTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function canRetryAFailedOrderNow()
     {
         $this->withMockedGetMollieMandateAccepted(3);
@@ -430,7 +432,7 @@ class OrderTest extends BaseTestCase
         $this->assertDatabaseHas('payments', ['mollie_payment_id' => 'tr_new_payment_id']);
     }
 
-    /** @test */
+    #[Test]
     public function storesOwnerCreditIfTotalIsPositiveAndSmallerThanMolliesMinimum()
     {
         Event::fake();
@@ -470,7 +472,7 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
-    /** @test */
+    #[Test]
     public function storesOwnerCreditIfTotalDueIsNegativeAndOwnerHasActiveSubscription()
     {
         Event::fake();
@@ -504,7 +506,7 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
-    /** @test */
+    #[Test]
     public function handlesNegativeTotalDueAndOwnerHasNoActiveSubscription()
     {
         Event::fake();
@@ -536,9 +538,7 @@ class OrderTest extends BaseTestCase
         });
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateOrderFromOrderItemsWhenTotalValueIsNegativeAndOwnerHasNoMandate()
     {
         Carbon::setTestNow(Carbon::parse('2018-01-01'));
@@ -587,9 +587,7 @@ class OrderTest extends BaseTestCase
         $this->assertMoneyEURCents(29998, $user->credit('EUR')->money());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canCreateOrderFromOrderItemsWhenTotalIsPaidByCreditAndOwnerHasNoMandate()
     {
         Carbon::setTestNow(Carbon::parse('2018-01-01'));
@@ -641,7 +639,7 @@ class OrderTest extends BaseTestCase
         $this->assertMoneyEURCents(0, $user->credit('EUR')->money());
     }
 
-    /** @test */
+    #[Test]
     public function canCreateProcessedOrderFromItems()
     {
         Event::fake();
@@ -661,7 +659,7 @@ class OrderTest extends BaseTestCase
 
         $order = Cashier::$orderModel::createProcessedFromItems($items, [
             'mollie_payment_id' => 'tr_123456',
-            'mollie_payment_status' => PaymentStatus::STATUS_PAID,
+            'mollie_payment_status' => PaymentStatus::PAID,
         ]);
 
         $this->assertNotNull($order);
@@ -670,7 +668,7 @@ class OrderTest extends BaseTestCase
         $this->assertTrue($order->isProcessed());
 
         $this->assertEquals('tr_123456', $order->mollie_payment_id);
-        $this->assertEquals(PaymentStatus::STATUS_PAID, $order->mollie_payment_status);
+        $this->assertEquals(PaymentStatus::PAID, $order->mollie_payment_status);
 
         $items->each(function ($item) {
             $this->assertTrue($item->isProcessed());
@@ -679,7 +677,7 @@ class OrderTest extends BaseTestCase
         $this->assertDispatchedOrderProcessed($order);
     }
 
-    /** @test */
+    #[Test]
     public function findByMolliePaymentIdWorks()
     {
         $this->assertNull(Cashier::$orderModel::findByMolliePaymentId('tr_xxxxx1234dummy'));
@@ -693,14 +691,14 @@ class OrderTest extends BaseTestCase
         $this->assertTrue($found->isNot($otherOrder));
     }
 
-    /** @test */
+    #[Test]
     public function findByMolliePaymentIdOrFailThrowsAnExceptionIfNotFound()
     {
         $this->expectException(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
         Cashier::$orderModel::findByMolliePaymentIdOrFail('tr_xxxxx1234dummy');
     }
 
-    /** @test */
+    #[Test]
     public function findByMolliePaymentIdOrFailWorks()
     {
         $order = OrderFactory::new()->create(['mollie_payment_id' => 'tr_xxxxx1234dummy']);
@@ -712,10 +710,8 @@ class OrderTest extends BaseTestCase
         $this->assertTrue($found->isNot($otherOrder));
     }
 
-    /**
-     * @test
-     * @group generate_new_invoice_template
-     */
+    #[Test]
+    #[Group('generate_new_invoice_template')]
     public function generateNewExampleInvoice()
     {
         $user = User::factory()->create(['extra_billing_information' => 'Some dummy extra billing information']);
@@ -732,28 +728,25 @@ class OrderTest extends BaseTestCase
         $filename = __DIR__ . '/../../example_invoice_output.html';
         $some_content = 'Invoice dummy';
 
-        if (collect($this->getGroups())->contains('generate_new_invoice_template')) {
-            $this->assertFileIsWritable($filename);
+        $this->assertFileIsWritable($filename);
 
-            if (is_writable($filename)) {
-                if (!$handle = fopen($filename, 'w')) {
-                    echo "Cannot open file ($filename)";
-                    exit;
-                }
-
-                if (fwrite($handle, $invoice->view()->render()) === false) {
-                    echo "Cannot write to file ($filename)";
-                    exit;
-                }
-
-                echo "Success, wrote ($some_content) to file ($filename)";
-
-                fclose($handle);
-            } else {
-                $this->fail('Cannot write example invoice to ' . $filename);
+        if (is_writable($filename)) {
+            if (!$handle = fopen($filename, 'w')) {
+                echo "Cannot open file ($filename)";
+                exit;
             }
+
+            if (fwrite($handle, $invoice->view()->render()) === false) {
+                echo "Cannot write to file ($filename)";
+                exit;
+            }
+
+            echo "Success, wrote ($some_content) to file ($filename)";
+
+            fclose($handle);
+        } else {
+            $this->fail('Cannot write example invoice to ' . $filename);
         }
-        $this->assertTrue(true, 'Unable to generate dummy invoice.');
     }
 
     /**

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -5,10 +5,11 @@ namespace Laravel\Cashier\Tests;
 use Laravel\Cashier\Cashier;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
+use PHPUnit\Framework\Attributes\Test;
 
 class PaymentTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canCreateFromBasicMolliePayment()
     {
         $molliePayment = new MolliePayment(new MollieApiClient);
@@ -35,7 +36,7 @@ class PaymentTest extends BaseTestCase
         $this->assertTrue($localPayment->owner->is($user));
     }
 
-    /** @test */
+    #[Test]
     public function canCreateFromMolliePaymentWithRefundsAndChargebacks()
     {
         $molliePayment = new MolliePayment(new MollieApiClient);

--- a/tests/Plan/ConfigPlanRepositoryTest.php
+++ b/tests/Plan/ConfigPlanRepositoryTest.php
@@ -55,10 +55,8 @@ class ConfigPlanRepositoryTest extends BaseTestCase
         $this->assertInstanceOf(Plan::class, ConfigPlanRepository::find('Test'));
     }
 
-    /**     * @throws \Laravel\Cashier\Exceptions\PlanNotFoundException
-     
-
-
+    /**
+     * @throws \Laravel\Cashier\Exceptions\PlanNotFoundException
      */
     #[Test]
     public function findOrFailCorrect()

--- a/tests/Plan/ConfigPlanRepositoryTest.php
+++ b/tests/Plan/ConfigPlanRepositoryTest.php
@@ -11,6 +11,7 @@ use Laravel\Cashier\Plan\ConfigPlanRepository;
 use Laravel\Cashier\Plan\Contracts\IntervalGeneratorContract;
 use Laravel\Cashier\Plan\Contracts\Plan;
 use Laravel\Cashier\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConfigPlanRepositoryTest extends BaseTestCase
 {
@@ -42,41 +43,44 @@ class ConfigPlanRepositoryTest extends BaseTestCase
         Config::set('cashier_plans.plans.Test', $this->testPlanArray);
     }
 
-    /** @test */
+    #[Test]
     public function findReturnsNullWhenNotFound()
     {
         $this->assertNull(ConfigPlanRepository::find('some_wrong_name'));
     }
 
-    /** @test */
+    #[Test]
     public function findReturnsPlanWhenFound()
     {
         $this->assertInstanceOf(Plan::class, ConfigPlanRepository::find('Test'));
     }
 
-    /** @test
-     * @throws \Laravel\Cashier\Exceptions\PlanNotFoundException
+    /**     * @throws \Laravel\Cashier\Exceptions\PlanNotFoundException
+     
+
+
      */
+    #[Test]
     public function findOrFailCorrect()
     {
         $this->assertInstanceOf(Plan::class, ConfigPlanRepository::findOrFail('Test'));
     }
 
-    /** @test */
+    #[Test]
     public function findOrFailWrong()
     {
         $this->expectException(PlanNotFoundException::class);
         ConfigPlanRepository::findOrFail('some_wrong_name');
     }
 
-    /** @test */
+    #[Test]
     public function findIsCaseSensitive()
     {
         $this->assertNull(ConfigPlanRepository::find('test'));
         $this->assertInstanceOf(Plan::class, ConfigPlanRepository::find('Test'));
     }
 
-    /** @test */
+    #[Test]
     public function populatesPlanProperlyWithoutDefaultsSet()
     {
         Config::set('cashier_plans.defaults', []); // clear Plan defaults
@@ -97,7 +101,7 @@ class ConfigPlanRepositoryTest extends BaseTestCase
         $this->assertCount(0, $plan->orderItemPreprocessors());
     }
 
-    /** @test */
+    #[Test]
     public function populatesPlanProperlyWithDefaultsSet()
     {
         Config::set('cashier_plans.defaults.first_payment', $this->firstPaymentDefaultsArray);

--- a/tests/Plan/ConfigPlanTest.php
+++ b/tests/Plan/ConfigPlanTest.php
@@ -6,6 +6,7 @@ use Laravel\Cashier\Plan\ConfigPlanRepository;
 use Laravel\Cashier\Plan\Plan;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Order\FakeOrderItemPreprocessor;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConfigPlanTest extends BaseTestCase
 {
@@ -44,7 +45,7 @@ class ConfigPlanTest extends BaseTestCase
         $this->plan = ConfigPlanRepository::populatePlan('Test', $this->configArray);
     }
 
-    /** @test */
+    #[Test]
     public function createFromConfigArrays()
     {
         $this->assertMoneyEURCents(1000, $this->plan->amount());
@@ -56,20 +57,20 @@ class ConfigPlanTest extends BaseTestCase
         $this->assertCount(1, $this->plan->orderItemPreprocessors());
     }
 
-    /** @test */
+    #[Test]
     public function getFirstPaymentAmount()
     {
         $amount = $this->plan->firstPaymentAmount();
         $this->assertMoneyEURCents(5, $amount);
     }
 
-    /** @test */
+    #[Test]
     public function getFirstPaymentDescription()
     {
         $this->assertEquals('Test mandate payment', $this->plan->firstPaymentDescription());
     }
 
-    /** @test */
+    #[Test]
     public function getPreprocessors()
     {
         $this->assertNotEmpty($this->plan->orderItemPreprocessors());

--- a/tests/Refunds/RefundTest.php
+++ b/tests/Refunds/RefundTest.php
@@ -14,10 +14,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\RefundFactory;
 use Mollie\Api\Types\RefundStatus as MollieRefundStatus;
+use PHPUnit\Framework\Attributes\Test;
 
 class RefundTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canHandleProcessedMollieRefund()
     {
         Event::fake();
@@ -36,12 +37,12 @@ class RefundTest extends BaseTestCase
         $refund->items()->saveMany(
             RefundItemCollection::makeFromOrderItemCollection($originalOrderItems)
         );
-        $this->assertEquals(MollieRefundStatus::STATUS_PENDING, $refund->mollie_refund_status);
+        $this->assertEquals(MollieRefundStatus::PENDING, $refund->mollie_refund_status);
 
         $refund = $refund->handleProcessed();
 
         $this->assertNotNull($refund->order_id);
-        $this->assertEquals(MollieRefundStatus::STATUS_REFUNDED, $refund->mollie_refund_status);
+        $this->assertEquals(MollieRefundStatus::REFUNDED, $refund->mollie_refund_status);
         $this->assertMoneyEURCents(29524, $originalOrder->refresh()->getAmountRefunded());
 
         $order = $refund->order;
@@ -55,7 +56,7 @@ class RefundTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function canHandleFailedMollieRefund()
     {
         Event::fake();
@@ -74,12 +75,12 @@ class RefundTest extends BaseTestCase
         $refund->items()->saveMany(
             RefundItemCollection::makeFromOrderItemCollection($originalOrderItems)
         );
-        $this->assertEquals(MollieRefundStatus::STATUS_PENDING, $refund->mollie_refund_status);
+        $this->assertEquals(MollieRefundStatus::PENDING, $refund->mollie_refund_status);
 
         $refund = $refund->handleFailed();
 
         $this->assertNull($refund->order_id);
-        $this->assertEquals(MollieRefundStatus::STATUS_FAILED, $refund->mollie_refund_status);
+        $this->assertEquals(MollieRefundStatus::FAILED, $refund->mollie_refund_status);
         $this->assertMoneyEURCents(0, $originalOrder->refresh()->getAmountRefunded());
 
         $this->assertNull($refund->order);

--- a/tests/Refunds/RefundsBuilderTest.php
+++ b/tests/Refunds/RefundsBuilderTest.php
@@ -16,17 +16,18 @@ use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Refund as MollieRefund;
 use Mollie\Api\Types\RefundStatus as MollieRefundStatus;
+use PHPUnit\Framework\Attributes\Test;
 
 class RefundsBuilderTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function can_create_a_refund_for_a_complete_order(): void
     {
         Event::fake();
         $this->mock(CreateMollieRefund::class, function (CreateMollieRefund $mock) {
             $mollieRefund = new MollieRefund(new MollieApiClient);
             $mollieRefund->id = 're_dummy_refund_id';
-            $mollieRefund->status = MollieRefundStatus::STATUS_PENDING;
+            $mollieRefund->status = MollieRefundStatus::PENDING;
             $mock->shouldReceive('execute')->with('tr_dummy_payment_id', [
                 'amount' => [
                     'value' => '22.00',
@@ -60,7 +61,7 @@ class RefundsBuilderTest extends BaseTestCase
 
         $this->assertInstanceOf(Cashier::$refundModel, $refund);
         $this->assertEquals('re_dummy_refund_id', $refund->mollie_refund_id);
-        $this->assertEquals(MollieRefundStatus::STATUS_PENDING, $refund->mollie_refund_status);
+        $this->assertEquals(MollieRefundStatus::PENDING, $refund->mollie_refund_status);
         $this->assertNull($refund->order_id);
 
         $refundItems = $refund->items;

--- a/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderApplyCorrectTaxTest.php
+++ b/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderApplyCorrectTaxTest.php
@@ -6,6 +6,7 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\SubscriptionBuilder\FirstPaymentSubscriptionBuilder;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Money\Money;
+use PHPUnit\Framework\Attributes\Test;
 
 class FirstPaymentSubscriptionBuilderApplyCorrectTaxTest extends BaseTestCase
 {
@@ -23,7 +24,7 @@ class FirstPaymentSubscriptionBuilderApplyCorrectTaxTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function handlesTrialDaysAndFirstPaymentWithTaxAppliedCorrectly()
     {
         $firstPaymentAmounts = collect(['10.00', '11.00', '21.00', '24.00', '280.00']);
@@ -43,7 +44,7 @@ class FirstPaymentSubscriptionBuilderApplyCorrectTaxTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function roundingModeReturnCorrectValue()
     {
         $down = $this->getBuilder()->roundingMode(Money::EUR(1000), 0.21); //total is 1001

--- a/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/FirstPaymentSubscriptionBuilderTest.php
@@ -18,6 +18,7 @@ use Laravel\Cashier\SubscriptionBuilder\RedirectToCheckoutResponse;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
+use PHPUnit\Framework\Attributes\Test;
 
 class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
 {
@@ -35,7 +36,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function createsAFirstPaymentForSubscription()
     {
         $firstPayment = config('cashier_plans.defaults.first_payment');
@@ -97,7 +98,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->assertEquals(20, $localPayment->first_payment_actions[1]->taxPercentage);
     }
 
-    /** @test */
+    #[Test]
     public function handlesQuantity()
     {
         config(['cashier.locale' => 'nl_NL']);
@@ -124,7 +125,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         ], $payload['amount']);
     }
 
-    /** @test */
+    #[Test]
     public function handlesAPaidFirstPayment()
     {
         $this->withoutExceptionHandling();
@@ -207,7 +208,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->assertSame(Order::first()->items->first()->description_extra_lines[0], 'From 2019-01-01 to 2019-02-01');
     }
 
-    /** @test */
+    #[Test]
     public function testWithCouponNoTrialValidatesCoupon()
     {
         $this->expectException(CouponException::class);
@@ -215,7 +216,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->getBuilder()->withCoupon('test-coupon')->create();
     }
 
-    /** @test */
+    #[Test]
     public function testWithCouponWithTrialValidatesCoupon()
     {
         $this->expectException(CouponException::class);
@@ -223,7 +224,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->getBuilder()->trialDays(5)->withCoupon('test-coupon')->create();
     }
 
-    /** @test */
+    #[Test]
     public function testWithCouponNoTrialModifiesThePaymentAmount()
     {
         $this->withMockedCouponRepository();
@@ -239,7 +240,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         $this->assertEquals('EUR', $amount['currency']);
     }
 
-    /** @test */
+    #[Test]
     public function testHandlesTrialDays()
     {
         $this->withMockedCreateMolliePayment();
@@ -254,7 +255,7 @@ class FirstPaymentSubscriptionBuilderTest extends BaseTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function testHandlesNoTrialMode()
     {
         $this->withMockedCreateMolliePayment();

--- a/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
+++ b/tests/SubscriptionBuilder/MandatedSubscriptionBuilderTest.php
@@ -7,6 +7,7 @@ use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\CouponException;
 use Laravel\Cashier\SubscriptionBuilder\MandatedSubscriptionBuilder;
 use Laravel\Cashier\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class MandatedSubscriptionBuilderTest extends BaseTestCase
 {
@@ -23,7 +24,7 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function testWithCouponNoTrial()
     {
         $this->withMockedCouponRepository();
@@ -81,7 +82,7 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
         $this->assertEquals(1, $orderItem->quantity);
     }
 
-    /** @test */
+    #[Test]
     public function testWithCouponValidatesCoupon()
     {
         $this->expectException(CouponException::class);
@@ -91,7 +92,7 @@ class MandatedSubscriptionBuilderTest extends BaseTestCase
         $this->getBuilder()->withCoupon('test-coupon')->create();
     }
 
-    /** @test */
+    #[Test]
     public function testSkipTrialWorks()
     {
         $builder = $this->getBuilder()->trialDays(5);

--- a/tests/SubscriptionTest.php
+++ b/tests/SubscriptionTest.php
@@ -12,6 +12,7 @@ use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
 use LogicException;
+use PHPUnit\Framework\Attributes\Test;
 
 class SubscriptionTest extends BaseTestCase
 {
@@ -20,7 +21,7 @@ class SubscriptionTest extends BaseTestCase
         parent::setUp();
     }
 
-    /** @test */
+    #[Test]
     public function canAccessOwner()
     {
         $user = User::factory()->create();
@@ -32,7 +33,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertTrue($user->is($subscription->owner));
     }
 
-    /** @test */
+    #[Test]
     public function canAccessOrderItems()
     {
         $subscription = SubscriptionFactory::new()->create();
@@ -44,7 +45,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertNotNull($items);
     }
 
-    /** @test */
+    #[Test]
     public function cannotScheduleNewOrderItemIfIdIsSet()
     {
         $this->expectException(LogicException::class);
@@ -68,7 +69,7 @@ class SubscriptionTest extends BaseTestCase
         $subscription->scheduleNewOrderItemAt(now());
     }
 
-    /** @test */
+    #[Test]
     public function cannotResumeIfNotCancelled()
     {
         $this->expectException(LogicException::class);
@@ -84,7 +85,7 @@ class SubscriptionTest extends BaseTestCase
         Event::assertNotDispatched(SubscriptionResumed::class);
     }
 
-    /** @test */
+    #[Test]
     public function cannotResumeIfNotOnGracePeriod()
     {
         $this->expectException(LogicException::class);
@@ -103,7 +104,7 @@ class SubscriptionTest extends BaseTestCase
         Event::assertNotDispatched(SubscriptionResumed::class);
     }
 
-    /** @test */
+    #[Test]
     public function getCycleProgressTest()
     {
         $now = now();
@@ -127,7 +128,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(0.5, $progressing_subscription->cycle_progress);
     }
 
-    /** @test */
+    #[Test]
     public function testSyncTaxPercentage()
     {
         $user = User::factory()->create();
@@ -142,7 +143,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(0, $subscription->tax_percentage);
     }
 
-    /** @test */
+    #[Test]
     public function yieldsOrderItemsAtSetIntervals()
     {
         Carbon::setTestNow(Carbon::parse('2018-01-01'));
@@ -225,7 +226,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertSame(null, $item_3->order_id);
     }
 
-    /** @test */
+    #[Test]
     public function yieldsOrderItemsAtSetIntervalsWithIntervalGenerator()
     {
         Carbon::setTestNow(Carbon::parse('2019-01-29'));
@@ -308,7 +309,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertSame(null, $item_3->order_id);
     }
 
-    /** @test */
+    #[Test]
     public function yieldsOrderItemsAtSetIntervalsWithIntervalGeneratorLastDayOfTheMonth()
     {
         Carbon::setTestNow(Carbon::parse('2019-01-31'));
@@ -416,7 +417,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertSame(null, $item_4->order_id);
     }
 
-    /** @test */
+    #[Test]
     public function cancelWorks()
     {
         $cycle_ends_at = now()->addWeek();
@@ -440,7 +441,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertTrue($subscription->onGracePeriod());
     }
 
-    /** @test */
+    #[Test]
     public function cancelAtWorks()
     {
         $user = User::factory()->create();
@@ -465,7 +466,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertTrue($subscription->onGracePeriod());
     }
 
-    /** @test */
+    #[Test]
     public function cancelNowWorks()
     {
         $user = User::factory()->create();
@@ -490,7 +491,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertFalse($subscription->onGracePeriod());
     }
 
-    /** @test */
+    #[Test]
     public function resumingACancelledSubscriptionResetsCycleEndsAt()
     {
         $this->withConfiguredPlans();
@@ -509,7 +510,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertCarbon(now()->addWeek(), $subscription->cycle_ends_at);
     }
 
-    /** @test */
+    #[Test]
     public function canQueryActiveSubscriptions()
     {
         SubscriptionFactory::new()
@@ -526,7 +527,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(1, Subscription::whereNotActive()->count());
     }
 
-    /** @test */
+    #[Test]
     public function canQueryOnTrialSubscriptions()
     {
         SubscriptionFactory::new()
@@ -542,7 +543,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(2, Subscription::whereNotOnTrial()->count());
     }
 
-    /** @test */
+    #[Test]
     public function canQueryOnGracePeriodSubscriptions()
     {
         SubscriptionFactory::new()
@@ -558,7 +559,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(2, Subscription::whereNotOnGracePeriod()->count());
     }
 
-    /** @test */
+    #[Test]
     public function canQueryCancelledSubscriptions()
     {
         SubscriptionFactory::new()
@@ -574,7 +575,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(2, Subscription::whereNotCancelled()->count());
     }
 
-    /** @test */
+    #[Test]
     public function canQueryRecurringSubscriptions()
     {
         SubscriptionFactory::new()
@@ -590,7 +591,7 @@ class SubscriptionTest extends BaseTestCase
         $this->assertEquals(2, Subscription::whereNotRecurring()->count());
     }
 
-    /** @test */
+    #[Test]
     public function halfwayThroughSubscriptionReturnsPositiveReimbursementAmount()
     {
         $this->withConfiguredPlans();
@@ -614,7 +615,7 @@ class SubscriptionTest extends BaseTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function nonReimbursableSubscriptionReturnsNoReimbursementAmount()
     {
         $this->withConfiguredPlans();

--- a/tests/SwapSubscriptionPlanTest.php
+++ b/tests/SwapSubscriptionPlanTest.php
@@ -10,6 +10,7 @@ use Laravel\Cashier\Order\Order;
 use Laravel\Cashier\Subscription;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class SwapSubscriptionPlanTest extends BaseTestCase
 {
@@ -23,7 +24,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         Event::fake();
     }
 
-    /** @test */
+    #[Test]
     public function canSwapToAnotherPlan()
     {
         $now = now();
@@ -110,9 +111,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         $this->assertFalse($scheduled_order_item->isProcessed());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function canSwapToAnotherPlanWithImmediatelyAppliedCoupon()
     {
         $now = now();
@@ -194,7 +193,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function swappingACancelledSubscriptionResumesIt()
     {
         $subscription = $this->getUser()->subscriptions()->save(
@@ -212,7 +211,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         $this->assertFalse($subscription->cancelled());
     }
 
-    /** @test */
+    #[Test]
     public function swappingACancelledSubscriptionAtNextCycleResumesIt()
     {
         $subscription = $this->getUser()->subscriptions()->save(
@@ -230,7 +229,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         $this->assertFalse($subscription->cancelled());
     }
 
-    /** @test */
+    #[Test]
     public function swappingOnTrialDoesNotCreateAnOrderEvenWhenInvoiceNowIsTrue()
     {
         $subscription = $this->getUser()->subscriptions()->save(
@@ -248,7 +247,7 @@ class SwapSubscriptionPlanTest extends BaseTestCase
         $this->assertEquals(0, Order::count());
     }
 
-    /** @test */
+    #[Test]
     public function canSwapNextCycle()
     {
         $user = $this->getUserWithZeroBalance();

--- a/tests/Traits/InteractsWithMocks.php
+++ b/tests/Traits/InteractsWithMocks.php
@@ -291,7 +291,18 @@ trait InteractsWithMocks
             return $mock->shouldReceive('execute')
                 ->with($wrongId, [])
                 ->times($times)
-                ->andThrow(new ApiException);
+                ->andThrow(new ApiException(
+                    \Mockery::mock(\Mollie\Api\Http\Response::class, [
+                        'json' => (object) ['status' => 404, 'title' => 'Not Found', '_links' => (object) []],
+                        'getPsrRequest' => \Mockery::mock(\Psr\Http\Message\RequestInterface::class, [
+                            'getBody' => \Mockery::mock(\Psr\Http\Message\StreamInterface::class, [
+                                '__toString' => '',
+                            ]),
+                        ]),
+                    ]),
+                    'Test exception',
+                    404,
+                ));
         });
     }
 

--- a/tests/UpdatePaymentMethod/UpdatePaymentMethodTest.php
+++ b/tests/UpdatePaymentMethod/UpdatePaymentMethodTest.php
@@ -11,10 +11,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
+use PHPUnit\Framework\Attributes\Test;
 
 class UpdatePaymentMethodTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canUpdatePaymentMethod()
     {
         $owner = User::factory()->create([

--- a/tests/UpdatePaymentMethod/UpdatePaymentMethodWithoutAddingToBalanceTest.php
+++ b/tests/UpdatePaymentMethod/UpdatePaymentMethodWithoutAddingToBalanceTest.php
@@ -12,10 +12,11 @@ use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
+use PHPUnit\Framework\Attributes\Test;
 
 class UpdatePaymentMethodWithoutAddingToBalanceTest extends BaseTestCase
 {
-    /** @test */
+    #[Test]
     public function canUpdatePaymentMethodWithoutAddingToBalance()
     {
         $owner = User::factory()->create([


### PR DESCRIPTION
## Summary

- Upgrade `mollie/laravel-mollie` from `^3.0` to `^4.0` and remove the direct `mollie/mollie-api-php` dependency (now transitive)
- Update all Mollie SDK constant references to match v4 naming (dropped `STATUS_`/`SEQUENCETYPE_` prefixes)
- Handle breaking changes in `RefundCollection` return type and `ApiException` constructor signature
- Migrate all PHPUnit annotations to PHP 8 attributes (`#[Test]`, `#[Group]`) for PHPUnit 11+/12+/13+ compatibility
- Require PHP 8.2+ and Laravel 11+
- Add CI `resolve` and `prefer-lowest` jobs

## Test plan

- [ ] CI passes on all PHP/Laravel matrix combinations
- [ ] `composer update --prefer-lowest` resolves successfully
- [ ] All existing tests pass with the updated Mollie SDK constants