### PR TITLE
build: bump phpunit constraints past GHSA-qrr6-mg7r-m243

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
     "orchestra/testbench": "^9.6|^10.0|^11.0",
-    "phpunit/phpunit": "^10.5|^11.5|^12.0|^13.0"
+    "phpunit/phpunit": "^10.5|^11.5|^12.5.22|^13.1.6"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
Restrict PHPUnit to patched versions for GHSA-qrr6-mg7r-m243.

Affected ranges:
- <= 12.5.21
- 13.0.0 to 13.1.5

This updates the Composer constraint to allow only patched 12.x and 13.x releases while keeping existing 10.x and 11.x support.