### PR TITLE
Lock webhook handlers against concurrent duplicate deliveries

### DIFF
--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\ChargebackReceived;
@@ -48,18 +49,32 @@ class AftercareWebhookController extends BaseWebhookController
             }
 
             $molliePaymentAmountChargedBackTotal = mollie_object_to_money($molliePayment->amountChargedBack);
-            $locallyKnownAmountChargedBack = $localPayment->getAmountChargedBack();
+            $chargeback = DB::transaction(function () use ($localPayment, $molliePaymentAmountChargedBackTotal) {
+                /** @var \Laravel\Cashier\Payment|null $localPayment */
+                $localPayment = Cashier::$paymentModel::whereKey($localPayment->getKey())->lockForUpdate()->first();
 
-            if ($locallyKnownAmountChargedBack->lessThan($molliePaymentAmountChargedBackTotal)) {
+                if (! $localPayment) {
+                    return null;
+                }
+
+                $locallyKnownAmountChargedBack = $localPayment->getAmountChargedBack();
+
+                if (! $locallyKnownAmountChargedBack->lessThan($molliePaymentAmountChargedBackTotal)) {
+                    return null;
+                }
+
                 $localPayment->amount_charged_back = (int) $molliePaymentAmountChargedBackTotal->getAmount();
                 $localPayment->save();
 
-                $amountChargedBackNow = $molliePaymentAmountChargedBackTotal->subtract(
-                    $locallyKnownAmountChargedBack
-                );
+                return [
+                    $localPayment,
+                    $molliePaymentAmountChargedBackTotal->subtract($locallyKnownAmountChargedBack),
+                ];
+            });
 
+            if ($chargeback) {
                 Event::dispatch(
-                    new ChargebackReceived($localPayment, $amountChargedBackNow)
+                    new ChargebackReceived($chargeback[0], $chargeback[1])
                 );
             }
         }

--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -49,32 +49,41 @@ class AftercareWebhookController extends BaseWebhookController
             }
 
             $molliePaymentAmountChargedBackTotal = mollie_object_to_money($molliePayment->amountChargedBack);
-            $chargeback = DB::transaction(function () use ($localPayment, $molliePaymentAmountChargedBackTotal) {
+            $updatedLocalPayment = null;
+            $amountChargedBackNow = null;
+
+            DB::transaction(function () use (
+                $localPayment,
+                $molliePaymentAmountChargedBackTotal,
+                &$updatedLocalPayment,
+                &$amountChargedBackNow
+            ) {
+                // A transaction alone does not lock rows that were read earlier. Re-read this
+                // payment with `SELECT ... FOR UPDATE` so concurrent aftercare deliveries cannot
+                // both compute the same old charged-back total and dispatch the event twice.
                 /** @var \Laravel\Cashier\Payment|null $localPayment */
                 $localPayment = Cashier::$paymentModel::whereKey($localPayment->getKey())->lockForUpdate()->first();
 
                 if (! $localPayment) {
-                    return null;
+                    return;
                 }
 
                 $locallyKnownAmountChargedBack = $localPayment->getAmountChargedBack();
 
                 if (! $locallyKnownAmountChargedBack->lessThan($molliePaymentAmountChargedBackTotal)) {
-                    return null;
+                    return;
                 }
 
                 $localPayment->amount_charged_back = (int) $molliePaymentAmountChargedBackTotal->getAmount();
                 $localPayment->save();
 
-                return [
-                    $localPayment,
-                    $molliePaymentAmountChargedBackTotal->subtract($locallyKnownAmountChargedBack),
-                ];
+                $updatedLocalPayment = $localPayment;
+                $amountChargedBackNow = $molliePaymentAmountChargedBackTotal->subtract($locallyKnownAmountChargedBack);
             });
 
-            if ($chargeback) {
+            if ($updatedLocalPayment && $amountChargedBackNow) {
                 Event::dispatch(
-                    new ChargebackReceived($chargeback[0], $chargeback[1])
+                    new ChargebackReceived($updatedLocalPayment, $amountChargedBackNow)
                 );
             }
         }

--- a/src/Http/Controllers/AftercareWebhookController.php
+++ b/src/Http/Controllers/AftercareWebhookController.php
@@ -70,7 +70,7 @@ class AftercareWebhookController extends BaseWebhookController
 
                 $locallyKnownAmountChargedBack = $localPayment->getAmountChargedBack();
 
-                if (! $locallyKnownAmountChargedBack->lessThan($molliePaymentAmountChargedBackTotal)) {
+                if ($locallyKnownAmountChargedBack->greaterThanOrEqual($molliePaymentAmountChargedBackTotal)) {
                     return;
                 }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -28,11 +28,14 @@ class WebhookController extends BaseWebhookController
                 switch ($payment->status) {
                     case PaymentStatus::PAID:
                         $order->handlePaymentPaid($payment);
-                        $payment->webhookUrl = route('webhooks.mollie.aftercare');
 
-                        /** @var UpdateMolliePayment $updateMolliePayment */
-                        $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-                        $updateMolliePayment->execute($payment);
+                        if ($order->wasPaymentStatusHandled()) {
+                            $payment->webhookUrl = route('webhooks.mollie.aftercare');
+
+                            /** @var UpdateMolliePayment $updateMolliePayment */
+                            $updateMolliePayment = app()->make(UpdateMolliePayment::class);
+                            $updateMolliePayment->execute($payment);
+                        }
 
                         break;
                     case PaymentStatus::FAILED:

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -28,14 +28,11 @@ class WebhookController extends BaseWebhookController
                 switch ($payment->status) {
                     case PaymentStatus::PAID:
                         $order->handlePaymentPaid($payment);
+                        $payment->webhookUrl = route('webhooks.mollie.aftercare');
 
-                        if ($order->wasPaymentStatusHandled()) {
-                            $payment->webhookUrl = route('webhooks.mollie.aftercare');
-
-                            /** @var UpdateMolliePayment $updateMolliePayment */
-                            $updateMolliePayment = app()->make(UpdateMolliePayment::class);
-                            $updateMolliePayment->execute($payment);
-                        }
+                        /** @var UpdateMolliePayment $updateMolliePayment */
+                        $updateMolliePayment = app()->make(UpdateMolliePayment::class);
+                        $updateMolliePayment->execute($payment);
 
                         break;
                     case PaymentStatus::FAILED:

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -78,6 +78,9 @@ class Order extends Model
 
     protected $guarded = [];
 
+    /** @var bool */
+    protected $paymentStatusHandled = false;
+
     /**
      * @return int
      */
@@ -445,35 +448,50 @@ class Order extends Model
      */
     public function handlePaymentFailed(MolliePayment $molliePayment)
     {
-        $localPayment = DB::transaction(function () use ($molliePayment) {
-            if ($this->creditApplied()) {
-                $this->owner->addCredit($this->getCreditUsed());
+        $this->paymentStatusHandled = false;
+        $handled = false;
+        $localPayment = DB::transaction(function () use ($molliePayment, &$handled) {
+            /** @var static $order */
+            $order = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
+
+            if ($order->mollie_payment_status === PaymentStatus::FAILED) {
+                return null;
             }
 
-            $this->update([
-                'mollie_payment_status' => 'failed',
+            if ($order->creditApplied()) {
+                $order->owner->addCredit($order->getCreditUsed());
+            }
+
+            $order->update([
+                'mollie_payment_status' => PaymentStatus::FAILED,
                 'balance_before' => 0,
                 'credit_used' => 0,
             ]);
 
             // It's possible a payment from Cashier v1 is not yet tracked in the Cashier database.
             // In that case we create a record here.
-            $localPayment = Cashier::$paymentModel::findByMolliePaymentOrCreate($molliePayment, $this->owner);
+            $localPayment = Cashier::$paymentModel::findByMolliePaymentOrCreate($molliePayment, $order->owner);
             $localPayment->update([
-                'mollie_payment_status' => 'failed',
-                'order_id' => $this->id,
+                'mollie_payment_status' => PaymentStatus::FAILED,
+                'order_id' => $order->id,
             ]);
 
-            $this->items->each(function (OrderItem $item) {
+            $order->items->each(function (OrderItem $item) {
                 $item->handlePaymentFailed();
             });
 
-            $this->owner->validateMollieMandate();
+            $order->owner->validateMollieMandate();
 
+            $handled = true;
             return $localPayment;
         });
 
-        Event::dispatch(new OrderPaymentFailed($this, $localPayment));
+        $this->refresh();
+        $this->paymentStatusHandled = $handled;
+
+        if ($handled) {
+            Event::dispatch(new OrderPaymentFailed($this, $localPayment));
+        }
 
         return $this;
     }
@@ -522,27 +540,52 @@ class Order extends Model
      */
     public function handlePaymentPaid(MolliePayment $molliePayment)
     {
-        $localPayment = DB::transaction(function () use ($molliePayment) {
-            $this->update(['mollie_payment_status' => 'paid']);
+        $this->paymentStatusHandled = false;
+        $handled = false;
+        $localPayment = DB::transaction(function () use ($molliePayment, &$handled) {
+            /** @var static $order */
+            $order = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
+
+            if ($order->mollie_payment_status === PaymentStatus::PAID) {
+                return null;
+            }
+
+            $order->update(['mollie_payment_status' => PaymentStatus::PAID]);
 
             // It's possible a payment from Cashier v1 is not yet tracked in the Cashier database.
             // In that case we create a record here.
-            $localPayment = Cashier::$paymentModel::findByMolliePaymentOrCreate($molliePayment, $this->owner);
+            $localPayment = Cashier::$paymentModel::findByMolliePaymentOrCreate($molliePayment, $order->owner);
             $localPayment->update([
-                'mollie_payment_status' => 'paid',
-                'order_id' => $this->id,
+                'mollie_payment_status' => PaymentStatus::PAID,
+                'order_id' => $order->id,
             ]);
 
-            $this->items->each(function (OrderItem $item) {
+            $order->items->each(function (OrderItem $item) {
                 $item->handlePaymentPaid();
             });
 
+            $handled = true;
             return $localPayment;
         });
 
-        Event::dispatch(new OrderPaymentPaid($this, $localPayment));
+        $this->refresh();
+        $this->paymentStatusHandled = $handled;
+
+        if ($handled) {
+            Event::dispatch(new OrderPaymentPaid($this, $localPayment));
+        }
 
         return $this;
+    }
+
+    /**
+     * Determine if the last payment status handler changed this order.
+     *
+     * @return bool
+     */
+    public function wasPaymentStatusHandled()
+    {
+        return $this->paymentStatusHandled;
     }
 
     /**

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -78,9 +78,6 @@ class Order extends Model
 
     protected $guarded = [];
 
-    /** @var bool */
-    protected $paymentStatusHandled = false;
-
     /**
      * @return int
      */
@@ -448,9 +445,10 @@ class Order extends Model
      */
     public function handlePaymentFailed(MolliePayment $molliePayment)
     {
-        $this->paymentStatusHandled = false;
         $handled = false;
         $localPayment = DB::transaction(function () use ($molliePayment, &$handled) {
+            // Webhook retries can arrive while callers still hold stale Order instances.
+            // Reload the current row under lock so credit restoration and item hooks run once.
             /** @var static $order */
             $order = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
 
@@ -468,9 +466,7 @@ class Order extends Model
                 'credit_used' => 0,
             ]);
 
-            // It's possible a payment from Cashier v1 is not yet tracked in the Cashier database.
-            // In that case we create a record here.
-            $localPayment = Cashier::$paymentModel::findByMolliePaymentOrCreate($molliePayment, $order->owner);
+            $localPayment = Cashier::$paymentModel::findByPaymentIdOrFail($molliePayment->id);
             $localPayment->update([
                 'mollie_payment_status' => PaymentStatus::FAILED,
                 'order_id' => $order->id,
@@ -487,7 +483,6 @@ class Order extends Model
         });
 
         $this->refresh();
-        $this->paymentStatusHandled = $handled;
 
         if ($handled) {
             Event::dispatch(new OrderPaymentFailed($this, $localPayment));
@@ -540,9 +535,10 @@ class Order extends Model
      */
     public function handlePaymentPaid(MolliePayment $molliePayment)
     {
-        $this->paymentStatusHandled = false;
         $handled = false;
         $localPayment = DB::transaction(function () use ($molliePayment, &$handled) {
+            // Paid webhooks have the same stale-instance problem: re-check under lock so the
+            // order transition, local payment update, and item hooks are idempotent.
             /** @var static $order */
             $order = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
 
@@ -552,9 +548,7 @@ class Order extends Model
 
             $order->update(['mollie_payment_status' => PaymentStatus::PAID]);
 
-            // It's possible a payment from Cashier v1 is not yet tracked in the Cashier database.
-            // In that case we create a record here.
-            $localPayment = Cashier::$paymentModel::findByMolliePaymentOrCreate($molliePayment, $order->owner);
+            $localPayment = Cashier::$paymentModel::findByPaymentIdOrFail($molliePayment->id);
             $localPayment->update([
                 'mollie_payment_status' => PaymentStatus::PAID,
                 'order_id' => $order->id,
@@ -569,23 +563,12 @@ class Order extends Model
         });
 
         $this->refresh();
-        $this->paymentStatusHandled = $handled;
 
         if ($handled) {
             Event::dispatch(new OrderPaymentPaid($this, $localPayment));
         }
 
         return $this;
-    }
-
-    /**
-     * Determine if the last payment status handler changed this order.
-     *
-     * @return bool
-     */
-    public function wasPaymentStatusHandled()
-    {
-        return $this->paymentStatusHandled;
     }
 
     /**

--- a/src/Refunds/Refund.php
+++ b/src/Refunds/Refund.php
@@ -78,16 +78,24 @@ class Refund extends Model
 
     public function handleProcessed(): self
     {
-        $refundItems = $this->items;
+        $handled = false;
 
-        DB::transaction(function () use ($refundItems) {
+        DB::transaction(function () use (&$handled) {
+            /** @var static $refund */
+            $refund = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
+
+            if ($refund->mollie_refund_status !== RefundStatus::PENDING) {
+                return;
+            }
+
+            $refundItems = $refund->items;
             $orderItems = $refundItems->toNewOrderItemCollection()->save();
             $order = Cashier::$orderModel::createProcessedFromItems($orderItems);
 
-            $this->order_id = $order->id;
-            $this->mollie_refund_status = RefundStatus::REFUNDED;
+            $refund->order_id = $order->id;
+            $refund->mollie_refund_status = RefundStatus::REFUNDED;
 
-            $this->save();
+            $refund->save();
 
             $refundItems->each(function (RefundItem $refundItem) {
                 $originalOrderItem = $refundItem->originalOrderItem;
@@ -98,29 +106,49 @@ class Refund extends Model
                 }
             });
 
-            $this->originalOrder->increment('amount_refunded', (int) $refundItems->getTotal()->getAmount());
+            $refund->originalOrder->increment('amount_refunded', (int) $refundItems->getTotal()->getAmount());
+
+            $handled = true;
         });
 
-        event(new RefundProcessed($this));
+        $this->refresh();
+
+        if ($handled) {
+            event(new RefundProcessed($this));
+        }
 
         return $this;
     }
 
     public function handleFailed(): self
     {
-        $refundItems = $this->items;
+        $handled = false;
 
-        DB::transaction(function () use ($refundItems) {
-            $this->mollie_refund_status = RefundStatus::FAILED;
+        DB::transaction(function () use (&$handled) {
+            /** @var static $refund */
+            $refund = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
 
-            $this->save();
+            if ($refund->mollie_refund_status !== RefundStatus::PENDING) {
+                return;
+            }
+
+            $refundItems = $refund->items;
+            $refund->mollie_refund_status = RefundStatus::FAILED;
+
+            $refund->save();
 
             $refundItems->each(function (RefundItem $refundItem) {
                 $refundItem->originalOrderItem->handlePaymentRefundFailed($refundItem);
             });
+
+            $handled = true;
         });
 
-        event(new RefundFailed($this));
+        $this->refresh();
+
+        if ($handled) {
+            event(new RefundFailed($this));
+        }
 
         return $this;
     }

--- a/src/Refunds/Refund.php
+++ b/src/Refunds/Refund.php
@@ -81,6 +81,8 @@ class Refund extends Model
         $handled = false;
 
         DB::transaction(function () use (&$handled) {
+            // Aftercare retries can process the same pending refund twice unless the refund row is
+            // locked and re-checked before creating the compensating order.
             /** @var static $refund */
             $refund = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
 
@@ -125,6 +127,8 @@ class Refund extends Model
         $handled = false;
 
         DB::transaction(function () use (&$handled) {
+            // Only a pending refund may transition to failed; locking keeps duplicate deliveries
+            // from re-running refund item failure hooks.
             /** @var static $refund */
             $refund = static::whereKey($this->getKey())->lockForUpdate()->firstOrFail();
 

--- a/tests/Fixtures/ChargebackStaleReadPayment.php
+++ b/tests/Fixtures/ChargebackStaleReadPayment.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Fixtures;
+
+class ChargebackStaleReadPayment extends Payment
+{
+    protected static int $remainingStaleReads = 0;
+
+    protected static int $staleAmountChargedBack = 0;
+
+    public static function returnStaleChargebackAmountOnNextReads(int $reads, int $amountChargedBack = 0): void
+    {
+        static::$remainingStaleReads = $reads;
+        static::$staleAmountChargedBack = $amountChargedBack;
+    }
+
+    public static function resetStaleChargebackReads(): void
+    {
+        static::$remainingStaleReads = 0;
+        static::$staleAmountChargedBack = 0;
+    }
+
+    public static function findByPaymentId($id): ?self
+    {
+        /** @var self|null $payment */
+        $payment = parent::findByPaymentId($id);
+
+        if (! $payment || static::$remainingStaleReads <= 0) {
+            return $payment;
+        }
+
+        static::$remainingStaleReads--;
+
+        /** @var self $stalePayment */
+        $stalePayment = clone $payment;
+        $stalePayment->amount_charged_back = static::$staleAmountChargedBack;
+
+        return $stalePayment;
+    }
+}

--- a/tests/Http/Controllers/AftercareWebhookControllerTest.php
+++ b/tests/Http/Controllers/AftercareWebhookControllerTest.php
@@ -111,17 +111,26 @@ class AftercareWebhookControllerTest extends BaseTestCase
         $mollieRefund->id = $mollieRefundId;
         $mollieRefund->status = MollieRefundStatus::REFUNDED;
 
-        $molliePayment = $this->getMockBuilder(MolliePayment::class)
-            ->setConstructorArgs([new MollieApiClient])
-            ->onlyMethods(['refunds'])
-            ->getMock();
+        $mollieRefunds = new RefundCollection(
+            $this->createStub(\Mollie\Api\Contracts\Connector::class),
+            [$mollieRefund],
+        );
 
-        $molliePayment
-            ->method('refunds')
-            ->willReturn(new RefundCollection(
-                $this->createMock(\Mollie\Api\Contracts\Connector::class),
-                [$mollieRefund],
-            ));
+        $molliePayment = new class(new MollieApiClient, $mollieRefunds) extends MolliePayment {
+            private RefundCollection $refunds;
+
+            public function __construct(MollieApiClient $client, RefundCollection $refunds)
+            {
+                parent::__construct($client);
+
+                $this->refunds = $refunds;
+            }
+
+            public function refunds(): RefundCollection
+            {
+                return $this->refunds;
+            }
+        };
 
         $molliePayment->id = $molliePaymentId;
         $molliePayment->status = MolliePaymentStatus::PAID;

--- a/tests/Http/Controllers/AftercareWebhookControllerTest.php
+++ b/tests/Http/Controllers/AftercareWebhookControllerTest.php
@@ -8,12 +8,14 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\ChargebackReceived;
+use Laravel\Cashier\Payment;
 use Laravel\Cashier\Events\RefundProcessed;
 use Laravel\Cashier\Http\Controllers\AftercareWebhookController;
 use Laravel\Cashier\Order\OrderItemCollection;
 use Laravel\Cashier\Refunds\RefundItemCollection;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
+use Laravel\Cashier\Tests\Fixtures\ChargebackStaleReadPayment;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
@@ -25,6 +27,14 @@ use PHPUnit\Framework\Attributes\Test;
 
 class AftercareWebhookControllerTest extends BaseTestCase
 {
+    protected function tearDown(): void
+    {
+        ChargebackStaleReadPayment::resetStaleChargebackReads();
+        Cashier::usePaymentModel(Payment::class);
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function itDetectsNewChargebacks()
     {
@@ -64,6 +74,47 @@ class AftercareWebhookControllerTest extends BaseTestCase
         $this->assertMoney(1000, 'EUR', $localPayment->getAmountChargedBack());
 
         Event::assertDispatched(ChargebackReceived::class);
+    }
+
+    #[Test]
+    public function itHandlesDuplicateChargebackDeliveriesWhenTheOuterPaymentReadIsStale()
+    {
+        Event::fake();
+        Cashier::usePaymentModel(ChargebackStaleReadPayment::class);
+
+        $molliePayment = new MolliePayment(new MollieApiClient);
+        $molliePayment->id = 'tr_duplicate_chargeback';
+        $molliePayment->status = 'paid';
+        $molliePayment->amount = (object) [
+            'currency' => 'EUR',
+            'value' => '20.00',
+        ];
+        $molliePayment->amountRefunded = null;
+        $molliePayment->amountChargedBack = null;
+        $molliePayment->_links = (object) [];
+
+        $localPayment = Cashier::$paymentModel::createFromMolliePayment($molliePayment, $this->getUser());
+        $molliePayment->amountChargedBack = (object) [
+            'value' => '10.00',
+            'currency' => 'EUR',
+        ];
+        $molliePayment->_links->chargebacks = (object) [
+            'href' => 'https://www.mollie.com/dashboard/org_12345678/payments/tr_WDqYK6vllg',
+            'type' => 'application/json',
+        ];
+
+        $this->withMockedGetMolliePayment(2, $molliePayment);
+        ChargebackStaleReadPayment::returnStaleChargebackAmountOnNextReads(2);
+
+        /** @var AftercareWebhookController $controller */
+        $controller = $this->app->make(AftercareWebhookController::class);
+
+        $controller->handleWebhook($this->getWebhookRequest($molliePayment->id));
+        $controller->handleWebhook($this->getWebhookRequest($molliePayment->id));
+
+        $localPayment->refresh();
+        $this->assertMoney(1000, 'EUR', $localPayment->getAmountChargedBack());
+        Event::assertDispatchedTimes(ChargebackReceived::class, 1);
     }
 
     #[Test]

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\BalanceTurnedStale;
 use Laravel\Cashier\Events\OrderCreated;
+use Laravel\Cashier\Events\OrderPaymentFailed;
 use Laravel\Cashier\Events\OrderPaymentFailedDueToInvalidMandate;
+use Laravel\Cashier\Events\OrderPaymentPaid;
 use Laravel\Cashier\Events\OrderProcessed;
 use Laravel\Cashier\Exceptions\AmountExceedsMolliePaymentMethodLimit;
 use Laravel\Cashier\Order\Invoice;
@@ -20,6 +22,8 @@ use Laravel\Cashier\Tests\Database\Factories\OrderFactory;
 use Laravel\Cashier\Tests\Database\Factories\OrderItemFactory;
 use Laravel\Cashier\Tests\Database\Factories\SubscriptionFactory;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Types\PaymentStatus;
 use Money\Currency;
 use Money\Money;
@@ -204,6 +208,91 @@ class OrderTest extends BaseTestCase
         $this->assertSame(0, $order->total_due);
         $this->assertSame(1000, $order->credit_used);
         $this->assertSame(1500, $order->balance_before);
+    }
+
+    #[Test]
+    public function handlesDuplicateFailedPaymentFromStaleOrderOnce()
+    {
+        Event::fake();
+
+        $user = User::factory()->create();
+        $paymentId = 'tr_failed_payment_id';
+        $molliePayment = new MolliePayment(new MollieApiClient);
+        $molliePayment->id = $paymentId;
+        $molliePayment->status = PaymentStatus::OPEN;
+        $molliePayment->amount = (object) [
+            'currency' => 'EUR',
+            'value' => '10.00',
+        ];
+        $molliePayment->mandateId = 'mdt_dummy_mandate_id';
+
+        $order = $user->orders()->save(OrderFactory::new()->make([
+            'mollie_payment_id' => $paymentId,
+            'mollie_payment_status' => PaymentStatus::OPEN,
+            'balance_before' => 500,
+            'credit_used' => 500,
+            'currency' => 'EUR',
+        ]));
+        Cashier::$paymentModel::createFromMolliePayment($molliePayment, $user);
+
+        $firstOrderInstance = Cashier::$orderModel::find($order->id);
+        $secondOrderInstance = Cashier::$orderModel::find($order->id);
+
+        $molliePayment->status = PaymentStatus::FAILED;
+
+        $firstOrderInstance->handlePaymentFailed($molliePayment);
+        $secondOrderInstance->handlePaymentFailed($molliePayment);
+
+        $this->assertTrue($firstOrderInstance->wasPaymentStatusHandled());
+        $this->assertFalse($secondOrderInstance->wasPaymentStatusHandled());
+
+        $order->refresh();
+        $this->assertEquals(PaymentStatus::FAILED, $order->mollie_payment_status);
+        $this->assertMoneyEURCents(0, $order->getBalanceBefore());
+        $this->assertMoneyEURCents(0, $order->getCreditUsed());
+        $this->assertMoneyEURCents(500, $user->credit('EUR')->money());
+        $this->assertEquals(PaymentStatus::FAILED, Cashier::$paymentModel::first()->mollie_payment_status);
+        Event::assertDispatchedTimes(OrderPaymentFailed::class, 1);
+    }
+
+    #[Test]
+    public function handlesDuplicatePaidPaymentFromStaleOrderOnce()
+    {
+        Event::fake();
+
+        $user = User::factory()->create();
+        $paymentId = 'tr_paid_payment_id';
+        $molliePayment = new MolliePayment(new MollieApiClient);
+        $molliePayment->id = $paymentId;
+        $molliePayment->status = PaymentStatus::OPEN;
+        $molliePayment->amount = (object) [
+            'currency' => 'EUR',
+            'value' => '10.00',
+        ];
+        $molliePayment->mandateId = 'mdt_dummy_mandate_id';
+
+        $order = $user->orders()->save(OrderFactory::new()->make([
+            'mollie_payment_id' => $paymentId,
+            'mollie_payment_status' => PaymentStatus::OPEN,
+            'currency' => 'EUR',
+        ]));
+        Cashier::$paymentModel::createFromMolliePayment($molliePayment, $user);
+
+        $firstOrderInstance = Cashier::$orderModel::find($order->id);
+        $secondOrderInstance = Cashier::$orderModel::find($order->id);
+
+        $molliePayment->status = PaymentStatus::PAID;
+
+        $firstOrderInstance->handlePaymentPaid($molliePayment);
+        $secondOrderInstance->handlePaymentPaid($molliePayment);
+
+        $this->assertTrue($firstOrderInstance->wasPaymentStatusHandled());
+        $this->assertFalse($secondOrderInstance->wasPaymentStatusHandled());
+
+        $order->refresh();
+        $this->assertEquals(PaymentStatus::PAID, $order->mollie_payment_status);
+        $this->assertEquals(PaymentStatus::PAID, Cashier::$paymentModel::first()->mollie_payment_status);
+        Event::assertDispatchedTimes(OrderPaymentPaid::class, 1);
     }
 
     #[Test]

--- a/tests/Order/OrderTest.php
+++ b/tests/Order/OrderTest.php
@@ -243,9 +243,6 @@ class OrderTest extends BaseTestCase
         $firstOrderInstance->handlePaymentFailed($molliePayment);
         $secondOrderInstance->handlePaymentFailed($molliePayment);
 
-        $this->assertTrue($firstOrderInstance->wasPaymentStatusHandled());
-        $this->assertFalse($secondOrderInstance->wasPaymentStatusHandled());
-
         $order->refresh();
         $this->assertEquals(PaymentStatus::FAILED, $order->mollie_payment_status);
         $this->assertMoneyEURCents(0, $order->getBalanceBefore());
@@ -285,9 +282,6 @@ class OrderTest extends BaseTestCase
 
         $firstOrderInstance->handlePaymentPaid($molliePayment);
         $secondOrderInstance->handlePaymentPaid($molliePayment);
-
-        $this->assertTrue($firstOrderInstance->wasPaymentStatusHandled());
-        $this->assertFalse($secondOrderInstance->wasPaymentStatusHandled());
 
         $order->refresh();
         $this->assertEquals(PaymentStatus::PAID, $order->mollie_payment_status);

--- a/tests/Refunds/RefundTest.php
+++ b/tests/Refunds/RefundTest.php
@@ -57,6 +57,40 @@ class RefundTest extends BaseTestCase
     }
 
     #[Test]
+    public function handlesDuplicateProcessedRefundFromStaleRefundOnce()
+    {
+        Event::fake();
+
+        $this->getCustomerUser();
+        $originalOrderItems = OrderItemFactory::new()->times(2)->create();
+        $originalOrder = Cashier::$orderModel::createProcessedFromItems($originalOrderItems);
+
+        /** @var Refund $refund */
+        $refund = RefundFactory::new()->create([
+            'original_order_id' => $originalOrder->id,
+            'total' => 29524,
+            'currency' => 'EUR',
+        ]);
+
+        $refund->items()->saveMany(
+            RefundItemCollection::makeFromOrderItemCollection($originalOrderItems)
+        );
+
+        $firstRefundInstance = Cashier::$refundModel::find($refund->id);
+        $secondRefundInstance = Cashier::$refundModel::find($refund->id);
+
+        $firstRefundInstance->handleProcessed();
+        $secondRefundInstance->handleProcessed();
+
+        $refund->refresh();
+        $this->assertEquals(MollieRefundStatus::REFUNDED, $refund->mollie_refund_status);
+        $this->assertNotNull($refund->order_id);
+        $this->assertEquals(2, Cashier::$orderModel::count());
+        $this->assertMoneyEURCents(29524, $originalOrder->refresh()->getAmountRefunded());
+        Event::assertDispatchedTimes(RefundProcessed::class, 1);
+    }
+
+    #[Test]
     public function canHandleFailedMollieRefund()
     {
         Event::fake();
@@ -88,5 +122,39 @@ class RefundTest extends BaseTestCase
         Event::assertDispatched(RefundFailed::class, function (RefundFailed $event) use ($refund) {
             return $event->refund->is($refund);
         });
+    }
+
+    #[Test]
+    public function handlesDuplicateFailedRefundFromStaleRefundOnce()
+    {
+        Event::fake();
+
+        $this->getCustomerUser();
+        $originalOrderItems = OrderItemFactory::new()->times(2)->create();
+        $originalOrder = Cashier::$orderModel::createProcessedFromItems($originalOrderItems);
+
+        /** @var Refund $refund */
+        $refund = RefundFactory::new()->create([
+            'original_order_id' => $originalOrder->id,
+            'total' => 29524,
+            'currency' => 'EUR',
+        ]);
+
+        $refund->items()->saveMany(
+            RefundItemCollection::makeFromOrderItemCollection($originalOrderItems)
+        );
+
+        $firstRefundInstance = Cashier::$refundModel::find($refund->id);
+        $secondRefundInstance = Cashier::$refundModel::find($refund->id);
+
+        $firstRefundInstance->handleFailed();
+        $secondRefundInstance->handleFailed();
+
+        $refund->refresh();
+        $this->assertEquals(MollieRefundStatus::FAILED, $refund->mollie_refund_status);
+        $this->assertNull($refund->order_id);
+        $this->assertEquals(1, Cashier::$orderModel::count());
+        $this->assertMoneyEURCents(0, $originalOrder->refresh()->getAmountRefunded());
+        Event::assertDispatchedTimes(RefundFailed::class, 1);
     }
 }


### PR DESCRIPTION
Protects customers and merchants from the financial side effects of duplicate webhook deliveries. Without this change, a retried or concurrent webhook can cause a customer to be credited twice for the same failed payment, receive two refund orders for a single refund, or have a chargeback counted more than once. This PR makes the paid, failed, refund, and chargeback webhook flows safe to deliver more than once, with no schema changes, migrations, cache locks, or new drivers required.

## Changes

- `Order::handlePaymentPaid` / `handlePaymentFailed`: reload the order with `lockForUpdate`, bail if already `paid`/`failed`, and only dispatch `OrderPaymentPaid` / `OrderPaymentFailed` when this call actually transitioned the row. Payment lookup switches to `findByPaymentIdOrFail` now that first-payment idempotency guarantees the row exists (#320).
- `Refund::handleProcessed` / `handleFailed`: lock the refund, bail unless still `pending`, and gate the `RefundProcessed` / `RefundFailed` event on the winning transaction so the compensating order and item hooks run once.
- `AftercareWebhookController` chargeback branch: wrap the charged-back comparison and update in a transaction that locks the payment row before recomputing the delta, so concurrent deliveries cannot both dispatch `ChargebackReceived` for the same amount.

## Tests

- Adds stale-instance regression coverage in `OrderTest` and `RefundTest`. Each handler is invoked on an outdated model instance whose row has already transitioned, and the test asserts no duplicate event, no duplicate credit/refund order, and no second increment.
- Adds `ChargebackStaleReadPayment` fixture and an aftercare test proving a stale `amount_charged_back` read does not produce a duplicate `ChargebackReceived`.
- Cleans up an unrelated PHPUnit deprecation notice in `AftercareWebhookControllerTest`.