### PR TITLE
Accept pending mandate when starting a first-payment subscription

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -502,11 +502,22 @@ trait Billable
     /**
      * Checks whether the Mollie mandate is still valid. If not, clears it.
      *
+     * When $acceptPending is true, a pending mandate is treated as valid. This is
+     * used by the first-payment flow where Mollie has already collected the
+     * payment and the mandate is guaranteed to finalize (see issue #289). For
+     * recurring/off-session charges the default strict behavior is preserved.
+     *
      * @return bool
+     *
+     * @throws \Laravel\Cashier\Exceptions\MandateIsNotYetFinalizedException
      */
-    public function validateMollieMandate()
+    public function validateMollieMandate(bool $acceptPending = false)
     {
         if ($this->pendingMollieMandate()) {
+            if ($acceptPending) {
+                return true;
+            }
+
             throw new MandateIsNotYetFinalizedException();
         }
 
@@ -523,10 +534,11 @@ trait Billable
      * @return bool
      *
      * @throws \Laravel\Cashier\Exceptions\InvalidMandateException
+     * @throws \Laravel\Cashier\Exceptions\MandateIsNotYetFinalizedException
      */
-    public function guardMollieMandate()
+    public function guardMollieMandate(bool $acceptPending = false)
     {
-        throw_unless($this->validateMollieMandate(), new InvalidMandateException());
+        throw_unless($this->validateMollieMandate($acceptPending), new InvalidMandateException());
 
         return true;
     }

--- a/src/FirstPayment/Actions/StartSubscription.php
+++ b/src/FirstPayment/Actions/StartSubscription.php
@@ -184,6 +184,12 @@ class StartSubscription extends BaseAction implements SubscriptionConfigurator
             $this->builder()->nextPaymentAt($this->plan->interval()->getEndOfNextSubscriptionCycle());
         }
 
+        // The first payment has already been collected by Mollie, so the mandate
+        // is guaranteed to finalize even when it is still pending at this point
+        // (e.g. PayPal or Belfius, where finalization can take up to 72h and
+        // exceeds Mollie's webhook retry window). See issue #289.
+        $this->builder()->acceptPendingMandate();
+
         // Create the subscription, scheduling the next payment
         $subscription = $this->builder()->create();
 

--- a/src/SubscriptionBuilder/MandatedSubscriptionBuilder.php
+++ b/src/SubscriptionBuilder/MandatedSubscriptionBuilder.php
@@ -66,6 +66,9 @@ class MandatedSubscriptionBuilder implements Contract
     /** @var bool */
     protected $validateCoupon = true;
 
+    /** @var bool */
+    protected $pendingMandateAccepted = false;
+
     /**
      * Create a new subscription builder instance.
      *
@@ -93,7 +96,7 @@ class MandatedSubscriptionBuilder implements Contract
      */
     public function create()
     {
-        $this->owner->guardMollieMandate();
+        $this->owner->guardMollieMandate($this->pendingMandateAccepted);
         $now = now();
 
         return DB::transaction(function () use ($now) {
@@ -239,6 +242,22 @@ class MandatedSubscriptionBuilder implements Contract
     public function skipCouponHandling()
     {
         $this->handleCoupon = false;
+
+        return $this;
+    }
+
+    /**
+     * Treat a pending Mollie mandate as valid when creating the subscription.
+     *
+     * Used by the first-payment flow: Mollie has already collected the payment
+     * and guarantees the mandate will finalize, even when finalization takes
+     * longer than the webhook retry window (PayPal, Belfius). See issue #289.
+     *
+     * @return $this
+     */
+    public function acceptPendingMandate(bool $accept = true)
+    {
+        $this->pendingMandateAccepted = $accept;
 
         return $this;
     }

--- a/tests/BillableTest.php
+++ b/tests/BillableTest.php
@@ -72,6 +72,31 @@ class BillableTest extends BaseTestCase
     }
 
     #[Test]
+    public function validateMollieMandateAcceptsPendingWhenOptedIn()
+    {
+        // Regression test for issue #289: callers in the first-payment flow can
+        // opt in to treating a pending mandate as valid, because Mollie has
+        // already collected the payment and guarantees finalization.
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandatePending();
+        $user = $this->getMandatedUser(false);
+
+        $this->assertTrue($user->validateMollieMandate(acceptPending: true));
+    }
+
+    #[Test]
+    public function validateMollieMandateStillRejectsPendingByDefault()
+    {
+        $this->expectException(MandateIsNotYetFinalizedException::class);
+
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandatePending();
+        $user = $this->getMandatedUser(false);
+
+        $user->validateMollieMandate();
+    }
+
+    #[Test]
     public function returnsDefaultSubscriptionBuilderIfOwnerHasValidMandateId()
     {
         $this->withConfiguredPlans();

--- a/tests/Charge/ManageChargesTest.php
+++ b/tests/Charge/ManageChargesTest.php
@@ -2,10 +2,14 @@
 
 namespace Laravel\Cashier\Tests\Charge;
 
+use Laravel\Cashier\Charge\ChargeItem;
 use Laravel\Cashier\Charge\FirstPaymentChargeBuilder;
 use Laravel\Cashier\Charge\MandatedChargeBuilder;
+use Laravel\Cashier\Exceptions\MandateIsNotYetFinalizedException;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
+use Money\Currency;
+use Money\Money;
 use PHPUnit\Framework\Attributes\Test;
 
 class ManageChargesTest extends BaseTestCase
@@ -29,5 +33,29 @@ class ManageChargesTest extends BaseTestCase
         ]);
 
         $this->assertInstanceOf(MandatedChargeBuilder::class, $owner->newCharge());
+    }
+
+    #[Test]
+    public function mandatedChargeStillRejectsPendingMandate()
+    {
+        // Regression test for issue #289: while the first-payment flow accepts
+        // a pending mandate (Mollie has already collected that payment),
+        // off-session/recurring charges must remain strict — a pending mandate
+        // offers no payment guarantee for charges initiated by the merchant.
+        $this->expectException(MandateIsNotYetFinalizedException::class);
+
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandatePending();
+        $owner = $this->getMandatedUser(true, [
+            'mollie_mandate_id' => 'mdt_unique_mandate_id',
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
+
+        $builder = new MandatedChargeBuilder($owner);
+        $builder->addItem(new ChargeItem(
+            $owner,
+            new Money(1000, new Currency('EUR')),
+            'Test charge'
+        ))->create();
     }
 }

--- a/tests/FirstPayment/Actions/StartSubscriptionTest.php
+++ b/tests/FirstPayment/Actions/StartSubscriptionTest.php
@@ -654,6 +654,72 @@ class StartSubscriptionTest extends BaseTestCase
         $this->assertEquals(20, $scheduledItem->tax_percentage);
     }
 
+    #[Test]
+    public function startsSubscriptionWhenMandateIsStillPending()
+    {
+        // Regression test for issue #289: PayPal and Belfius mandates can remain
+        // pending for up to 72h after the first payment, which exceeds Mollie's
+        // webhook retry window. The first payment is already collected and the
+        // mandate is guaranteed to finalize, so the subscription must be started.
+        Carbon::setTestNow('2019-01-29');
+
+        $user = $this->getMandatedUser(true);
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandatePending();
+
+        $this->assertFalse($user->subscribed('default'));
+
+        $action = new StartSubscription(
+            $user,
+            'default',
+            'monthly-10-1'
+        );
+
+        $items = $action->execute();
+        $user = $user->fresh();
+
+        $this->assertTrue($user->subscribed('default'));
+        $this->assertInstanceOf(OrderItemCollection::class, $items);
+        $this->assertCount(1, $items);
+
+        $subscription = $user->subscription('default');
+        $this->assertEquals(2, $subscription->orderItems()->count());
+    }
+
+    #[Test]
+    public function startsSubscriptionWithTrialDaysWhenMandateIsStillPending()
+    {
+        // Regression test for issue #289: covers the trial branch of
+        // MandatedSubscriptionBuilder::create() to ensure the pending-mandate
+        // opt-in also applies when the subscription starts on a trial.
+        $user = $this->getMandatedUser(true, ['tax_percentage' => 20]);
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandatePending();
+
+        $this->assertFalse($user->subscribed('default'));
+
+        $action = new StartSubscription(
+            $user,
+            'default',
+            'monthly-10-1'
+        );
+
+        $action->trialDays(5);
+
+        $items = $action->execute();
+        $user = $user->fresh();
+
+        $this->assertTrue($user->subscribed('default'));
+        $this->assertTrue($user->onTrial());
+        $this->assertInstanceOf(OrderItemCollection::class, $items);
+        $this->assertCount(1, $items);
+
+        $subscription = $user->subscription('default');
+        $this->assertEquals(2, $subscription->orderItems()->count());
+        $this->assertCarbon(now()->addDays(5), $subscription->cycle_ends_at);
+        $this->assertCarbon(now()->addDays(5), $subscription->trial_ends_at);
+    }
+
     /**
      * Check if the action can be built using the payload, and then can return the same payload.
      *

--- a/tests/FirstPayment/FirstPaymentHandlerTest.php
+++ b/tests/FirstPayment/FirstPaymentHandlerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\MandateUpdated;
 use Laravel\Cashier\FirstPayment\Actions\AddBalance;
+use Laravel\Cashier\FirstPayment\Actions\StartSubscription;
 use Laravel\Cashier\FirstPayment\FirstPaymentHandler;
 use Laravel\Cashier\Tests\BaseTestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
@@ -83,6 +84,75 @@ class FirstPaymentHandlerTest extends BaseTestCase
 
             return true;
         });
+    }
+
+    #[Test]
+    public function startsSubscriptionWhenMandateIsStillPending()
+    {
+        // End-to-end regression for issue #289: this exercises the path
+        // FirstPaymentWebhookController → FirstPaymentHandler::execute()
+        // → StartSubscription::execute() → MandatedSubscriptionBuilder::create()
+        // with a pending mandate, which is the exact scenario reported for
+        // PayPal and Belfius first payments.
+        Event::fake();
+        $this->withConfiguredPlans();
+        $this->withMockedGetMollieCustomer();
+        $this->withMockedGetMollieMandatePending();
+
+        $molliePayment = $this->getStartSubscriptionPaymentStub();
+
+        $owner = User::factory()->create([
+            'id' => $molliePayment->metadata->owner->id,
+            'mollie_customer_id' => 'cst_unique_customer_id',
+        ]);
+        Cashier::$paymentModel::createFromMolliePayment($molliePayment, $owner);
+
+        $this->assertFalse($owner->subscribed('default'));
+
+        $handler = new FirstPaymentHandler($molliePayment);
+        $order = $handler->execute();
+
+        $owner = $owner->fresh();
+
+        $this->assertTrue($owner->subscribed('default'));
+        $this->assertEquals('mdt_unique_mandate_id', $owner->mollie_mandate_id);
+        $this->assertInstanceOf(Cashier::$orderModel, $order);
+        $this->assertTrue($order->isProcessed());
+
+        Event::assertDispatched(MandateUpdated::class);
+    }
+
+    protected function getStartSubscriptionPaymentStub(): MolliePayment
+    {
+        $payment = new MolliePayment(new MollieApiClient);
+        $payment->sequenceType = 'first';
+        $payment->id = 'tr_unique_start_subscription_payment_id';
+        $payment->customerId = 'cst_unique_customer_id';
+        $payment->mandateId = 'mdt_unique_mandate_id';
+        $payment->amount = (object) ['value' => '10.00', 'currency' => 'EUR'];
+        $payment->status = PaymentStatus::PAID;
+        $payment->metadata = json_decode(json_encode([
+            'owner' => [
+                'type' => User::class,
+                'id' => 1,
+            ],
+            'actions' => [
+                [
+                    'handler' => StartSubscription::class,
+                    'description' => 'Monthly payment',
+                    'subtotal' => [
+                        'currency' => 'EUR',
+                        'value' => '10.00',
+                    ],
+                    'taxPercentage' => 0,
+                    'plan' => 'monthly-10-1',
+                    'name' => 'default',
+                    'quantity' => 1,
+                ],
+            ],
+        ]));
+
+        return $payment;
     }
 
     protected function getMandatePaymentStub(): MolliePayment


### PR DESCRIPTION
# Accept pending mandate when starting a first-payment subscription

Closes #289.

## Problem

After a successful first payment via PayPal or Belfius, the customer's mandate
stays in `pending` state — sometimes for up to 72 hours, until Mollie receives
the IBAN/account confirmation from the upstream payment scheme. During that
window `MandatedSubscriptionBuilder::create()` calls `guardMollieMandate()`,
which unconditionally throws `MandateIsNotYetFinalizedException` when the
mandate is pending. The webhook fails, Mollie retries with exponential
back-off, but its retry window (≈26h) is shorter than PayPal's and Belfius's
finalization window (up to 72h). The result: the customer has paid, the
mandate eventually becomes valid, but the subscription is never started.

This was also seen sporadically on cards in test mode and is the most
frequently reopened complaint on this issue (April 2025 → February 2026).

Mollie's own recurring-payments documentation states that a subscription
should be created when the mandate is in either `pending` or `valid` status —
the first payment is already collected and the mandate is guaranteed to
finalize. The strict guard was introduced in #94 specifically to leverage
Mollie's webhook retry as a workaround for Belfius (#70); with PayPal added
to the long-pending category, that workaround no longer covers the window.

### Reproduction (before this PR)

1. Configure a plan with PayPal (or Belfius) as the first-payment method.
2. Create a subscription via `newSubscriptionViaMollieCheckout(...)->create()`.
3. The customer completes the PayPal payment.
4. Mollie delivers the first-payment webhook within seconds.
5. `MandatedSubscriptionBuilder::create()` calls `guardMollieMandate()`, the
   mandate API still reports `status: pending`, and the handler throws
   `MandateIsNotYetFinalizedException`.
6. Mollie retries the webhook with exponential back-off (capped at ~26h).
7. The mandate transitions to `valid` 24–72h later — after Mollie has
   already stopped retrying.
8. Result: the customer has paid, but the subscription is never started.

With this PR step 5 succeeds on the first webhook delivery; the subscription
is created, the customer's mandate continues finalizing in the background,
and the `MandateUpdated` event still fires as before.

## Solution

Treat a pending mandate as valid in the first-payment flow only. Recurring /
off-session charges (`MandatedChargeBuilder`, `Order::processFullPayment`,
direct `MandatedSubscriptionBuilder::create()`, `newSubscriptionForMandateId`)
keep the existing strict behavior — for merchant-initiated charges a pending
mandate offers no payment guarantee.

## Changes

- `Billable::validateMollieMandate(bool $acceptPending = false)`: optional
  parameter; when `true`, a pending mandate returns `true` instead of throwing.
  Default is `false`, so all existing callers behave exactly as before.
- `Billable::guardMollieMandate(bool $acceptPending = false)`: forwards the
  flag to `validateMollieMandate`.
- `MandatedSubscriptionBuilder::acceptPendingMandate(bool $accept = true)`:
  new fluent setter. `create()` passes the stored flag to
  `guardMollieMandate()`. The `SubscriptionBuilder` contract is unchanged.
- `FirstPayment\Actions\StartSubscription::execute()`: calls
  `$this->builder()->acceptPendingMandate()` before `create()`, so the
  webhook-triggered first-payment flow opts in to the relaxed validation.

No public API breakage, no schema changes, no new dependencies.

## Tests

- `FirstPaymentHandlerTest::startsSubscriptionWhenMandateIsStillPending`:
  end-to-end coverage from `FirstPaymentHandler::execute()` through
  `StartSubscription::execute()` to subscription creation with a pending
  mandate — the exact scenario reported on PayPal and Belfius.
- `StartSubscriptionTest::startsSubscriptionWhenMandateIsStillPending` and
  `startsSubscriptionWithTrialDaysWhenMandateIsStillPending`: action-level
  coverage for the default and trial branches of subscription creation.
- `ManageChargesTest::mandatedChargeStillRejectsPendingMandate`: an
  off-session charge against the same pending mandate still throws
  `MandateIsNotYetFinalizedException`.
- `BillableTest::validateMollieMandateAcceptsPendingWhenOptedIn` and
  `validateMollieMandateStillRejectsPendingByDefault`: unit-level coverage
  of the new opt-in parameter on both branches.
- The pre-existing `BillableTest::throwExceptionIfMandateIsInPendingState`
  remains green — it exercises `newSubscriptionForMandateId`, which does not
  opt in and must still throw.

Full suite: `./vendor/bin/phpunit` — 249 tests, 1897 assertions, all green.

## What this does not change

- Aftercare webhook, refund, chargeback handling: unchanged.
- Behavior when the mandate later transitions to `invalid` (e.g. Belfius IBAN
  comes back unusable) is unchanged: `MandateClearedFromBillable` still fires
  on the next charge attempt, and the merchant can react via the existing
  event.
- This PR does not add polling or reconciliation for pending mandates that
  never finalize within Mollie's retry window — that scenario is now
  superseded by accepting the pending mandate up front, because Mollie has
  guaranteed the first payment at that point.
