### PR TITLE
Pin Testbench per Laravel major in CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3.5.3
+              uses: actions/checkout@v6
               with:
                   persist-credentials: false
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,31 +14,10 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ 8.4, 8.3, 8.2 ]
-                include:
-                    - php: 8.4
-                      laravel: 13.*
-                      testbench: ^11.0
-                    - php: 8.3
-                      laravel: 13.*
-                      testbench: ^11.0
-                    - php: 8.4
-                      laravel: 12.*
-                      testbench: ^10.0
-                    - php: 8.3
-                      laravel: 12.*
-                      testbench: ^10.0
+                laravel: [ 13.*, 12.*, 11.* ]
+                exclude:
                     - php: 8.2
-                      laravel: 12.*
-                      testbench: ^10.0
-                    - php: 8.4
-                      laravel: 11.*
-                      testbench: ^9.6
-                    - php: 8.3
-                      laravel: 11.*
-                      testbench: ^9.6
-                    - php: 8.2
-                      laravel: 11.*
-                      testbench: ^9.6
+                      laravel: 13.*
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -50,9 +29,19 @@ jobs:
                   extensions: curl, dom, intl, json, libxml, mbstring, openssl, zip
                   tools: composer:v2
 
+            - name: Allow Laravel 11 compatibility installs
+              if: matrix.laravel == '11.*'
+              run: composer config --global policy.advisories.block false
+
             - name: Check dependency resolution
               run: |
-                  composer require illuminate/support:${{ matrix.laravel }} orchestra/testbench:${{ matrix.testbench }} --no-update --no-interaction
+                  case "${{ matrix.laravel }}" in
+                      13.*) testbench="^11.0" ;;
+                      12.*) testbench="^10.0" ;;
+                      11.*) testbench="^9.6" ;;
+                  esac
+                  composer require "illuminate/support:${{ matrix.laravel }}" --no-update --no-interaction
+                  composer require --dev "orchestra/testbench:${testbench}" --no-update --no-interaction
                   composer update --prefer-stable --prefer-dist --no-interaction --no-progress --dry-run
 
     tests:
@@ -63,39 +52,11 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ 8.4, 8.3, 8.2 ]
-                include:
-                    - php: 8.4
-                      laravel: 13.*
-                      testbench: ^11.0
-                      dependency-version: prefer-stable
-                    - php: 8.3
-                      laravel: 13.*
-                      testbench: ^11.0
-                      dependency-version: prefer-stable
-                    - php: 8.4
-                      laravel: 12.*
-                      testbench: ^10.0
-                      dependency-version: prefer-stable
-                    - php: 8.3
-                      laravel: 12.*
-                      testbench: ^10.0
-                      dependency-version: prefer-stable
+                laravel: [ 13.*, 12.*, 11.* ]
+                dependency-version: [ prefer-stable ]
+                exclude:
                     - php: 8.2
-                      laravel: 12.*
-                      testbench: ^10.0
-                      dependency-version: prefer-stable
-                    - php: 8.4
-                      laravel: 11.*
-                      testbench: ^9.6
-                      dependency-version: prefer-stable
-                    - php: 8.3
-                      laravel: 11.*
-                      testbench: ^9.6
-                      dependency-version: prefer-stable
-                    - php: 8.2
-                      laravel: 11.*
-                      testbench: ^9.6
-                      dependency-version: prefer-stable
+                      laravel: 13.*
 
         steps:
             - name: Checkout code
@@ -109,9 +70,19 @@ jobs:
                   tools: composer:v2
                   coverage: xdebug
 
+            - name: Allow Laravel 11 compatibility installs
+              if: matrix.laravel == '11.*'
+              run: composer config --global policy.advisories.block false
+
             - name: Install dependencies
               run: |
-                  composer require illuminate/support:${{ matrix.laravel }} orchestra/testbench:${{ matrix.testbench }} --no-update --no-interaction
+                  case "${{ matrix.laravel }}" in
+                      13.*) testbench="^11.0" ;;
+                      12.*) testbench="^10.0" ;;
+                      11.*) testbench="^9.6" ;;
+                  esac
+                  composer require "illuminate/support:${{ matrix.laravel }}" --no-update --no-interaction
+                  composer require --dev "orchestra/testbench:${testbench}" --no-update --no-interaction
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
 
             - name: Execute tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
                       laravel: 13.*
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -55,7 +55,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -83,7 +83,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ 8.4, 8.3, 8.2 ]
-                laravel: [ 13.*, 12.*, 11.* ]
+                laravel: [ 13.*, 12.* ]
                 exclude:
                     - php: 8.2
                       laravel: 13.*
@@ -29,16 +29,11 @@ jobs:
                   extensions: curl, dom, intl, json, libxml, mbstring, openssl, zip
                   tools: composer:v2
 
-            - name: Allow Laravel 11 compatibility installs
-              if: matrix.laravel == '11.*'
-              run: composer config --global policy.advisories.block false
-
             - name: Check dependency resolution
               run: |
                   case "${{ matrix.laravel }}" in
                       13.*) testbench="^11.0" ;;
                       12.*) testbench="^10.0" ;;
-                      11.*) testbench="^9.6" ;;
                   esac
                   composer require "illuminate/support:${{ matrix.laravel }}" --no-update --no-interaction
                   composer require --dev "orchestra/testbench:${testbench}" --no-update --no-interaction
@@ -52,7 +47,7 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ 8.4, 8.3, 8.2 ]
-                laravel: [ 13.*, 12.*, 11.* ]
+                laravel: [ 13.*, 12.* ]
                 dependency-version: [ prefer-stable ]
                 exclude:
                     - php: 8.2
@@ -70,16 +65,11 @@ jobs:
                   tools: composer:v2
                   coverage: xdebug
 
-            - name: Allow Laravel 11 compatibility installs
-              if: matrix.laravel == '11.*'
-              run: composer config --global policy.advisories.block false
-
             - name: Install dependencies
               run: |
                   case "${{ matrix.laravel }}" in
                       13.*) testbench="^11.0" ;;
                       12.*) testbench="^10.0" ;;
-                      11.*) testbench="^9.6" ;;
                   esac
                   composer require "illuminate/support:${{ matrix.laravel }}" --no-update --no-interaction
                   composer require --dev "orchestra/testbench:${testbench}" --no-update --no-interaction

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,10 +14,31 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ 8.4, 8.3, 8.2 ]
-                laravel: [ 13.*, 12.*, 11.* ]
-                exclude:
-                    - php: 8.2
+                include:
+                    - php: 8.4
                       laravel: 13.*
+                      testbench: ^11.0
+                    - php: 8.3
+                      laravel: 13.*
+                      testbench: ^11.0
+                    - php: 8.4
+                      laravel: 12.*
+                      testbench: ^10.0
+                    - php: 8.3
+                      laravel: 12.*
+                      testbench: ^10.0
+                    - php: 8.2
+                      laravel: 12.*
+                      testbench: ^10.0
+                    - php: 8.4
+                      laravel: 11.*
+                      testbench: ^9.6
+                    - php: 8.3
+                      laravel: 11.*
+                      testbench: ^9.6
+                    - php: 8.2
+                      laravel: 11.*
+                      testbench: ^9.6
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -31,7 +52,7 @@ jobs:
 
             - name: Check dependency resolution
               run: |
-                  composer require illuminate/support:${{ matrix.laravel }} --no-update --no-interaction
+                  composer require illuminate/support:${{ matrix.laravel }} orchestra/testbench:${{ matrix.testbench }} --no-update --no-interaction
                   composer update --prefer-stable --prefer-dist --no-interaction --no-progress --dry-run
 
     tests:
@@ -42,11 +63,39 @@ jobs:
             fail-fast: true
             matrix:
                 php: [ 8.4, 8.3, 8.2 ]
-                laravel: [ 13.*, 12.*, 11.* ]
-                dependency-version: [ prefer-stable ]
-                exclude:
-                    - php: 8.2
+                include:
+                    - php: 8.4
                       laravel: 13.*
+                      testbench: ^11.0
+                      dependency-version: prefer-stable
+                    - php: 8.3
+                      laravel: 13.*
+                      testbench: ^11.0
+                      dependency-version: prefer-stable
+                    - php: 8.4
+                      laravel: 12.*
+                      testbench: ^10.0
+                      dependency-version: prefer-stable
+                    - php: 8.3
+                      laravel: 12.*
+                      testbench: ^10.0
+                      dependency-version: prefer-stable
+                    - php: 8.2
+                      laravel: 12.*
+                      testbench: ^10.0
+                      dependency-version: prefer-stable
+                    - php: 8.4
+                      laravel: 11.*
+                      testbench: ^9.6
+                      dependency-version: prefer-stable
+                    - php: 8.3
+                      laravel: 11.*
+                      testbench: ^9.6
+                      dependency-version: prefer-stable
+                    - php: 8.2
+                      laravel: 11.*
+                      testbench: ^9.6
+                      dependency-version: prefer-stable
 
         steps:
             - name: Checkout code
@@ -62,7 +111,7 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer require illuminate/support:${{ matrix.laravel }} --no-update --no-interaction
+                  composer require illuminate/support:${{ matrix.laravel }} orchestra/testbench:${{ matrix.testbench }} --no-update --no-interaction
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
 
             - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     "ext-json": "*",
     "ext-intl": "*",
     "dompdf/dompdf": "^2.0|^3.0",
-    "illuminate/database": "^11|^12|^13",
-    "illuminate/support": "^11|^12|^13",
+    "illuminate/database": "^12|^13",
+    "illuminate/support": "^12|^13",
     "mollie/laravel-mollie": "^4.0",
     "moneyphp/money": "^4.1",
     "nesbot/carbon": "^2.72|^3.0"
@@ -43,7 +43,7 @@
   "require-dev": {
     "guzzlehttp/guzzle": "^7.0",
     "mockery/mockery": "^1.4",
-    "orchestra/testbench": "^9.6|^10.0|^11.0",
+    "orchestra/testbench": "^10.0|^11.0",
     "phpunit/phpunit": "^10.5|^11.5|^12.5.22|^13.1.6"
   },
   "autoload": {


### PR DESCRIPTION
## Summary
- drop Laravel 11 from the supported Composer constraints and CI matrix
- keep Composer security advisory blocking enabled in CI
- keep Laravel 12 jobs on Testbench 10.x and Laravel 13 jobs on Testbench 11.x
- preserve the compact PHP x Laravel matrix instead of listing every supported combination manually
- update `actions/checkout` to v6 so workflow jobs run the checkout action on Node 24

## Why
Laravel 11 is no longer receiving Laravel security fixes, and Composer 2.10 now blocks the Laravel 11 framework versions selected by the Testbench 9.x lane because Packagist reports active security advisories.

Rather than disabling Composer advisory blocking, this PR stops advertising and testing Laravel 11 support. The remaining Laravel 12 and 13 compatibility lanes resolve with security checks intact.

The checkout action update also removes the GitHub Actions annotation about Node.js 20 actions being deprecated.

## Verification
- `composer validate --strict`
- Composer 2.10.1 secure resolver dry-run
- GitHub Actions test workflow is green for both triggered runs
